### PR TITLE
Add terminal tool and remove python execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,8 @@ and demonstrates basic tool usage. Chat histories are stored in a local SQLite
 database using Peewee. Histories are persisted per user and session so
 conversations can be resumed with context. One example tool is included:
 
-* **execute_python** – Executes Python code in a sandbox with selected built-ins
-  and allows importing safe modules like ``math``. The result is returned from a
-  ``result`` variable or captured output.
+* **execute_terminal** – Executes a shell command in a Linux VM with network
+  access. Output from ``stdout`` and ``stderr`` is captured and returned.
 
 The application now injects a system prompt that instructs the model to chain
 multiple tools when required. This prompt ensures the assistant can orchestrate
@@ -19,4 +18,4 @@ tool calls in sequence to satisfy the user's request.
 python run.py
 ```
 
-The script will ask the model to compute an arithmetic expression and print the answer. Conversations are automatically persisted to `chat.db` and are now associated with a user and session.
+The script will instruct the model to run a simple shell command and print the result. Conversations are automatically persisted to `chat.db` and are now associated with a user and session.

--- a/run.py
+++ b/run.py
@@ -8,7 +8,7 @@ from src.chat import ChatSession
 async def _main() -> None:
     async with ChatSession(user="demo_user", session="demo_session") as chat:
         answer = await chat.chat(
-            "Run this Python code: import math\nresult = math.factorial(5)"
+            "Execute this command: echo Hello from the VM"
         )
         print("\n>>>", answer)
 

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,4 +1,4 @@
 from .chat import ChatSession
-from .tools import execute_python
+from .tools import execute_terminal
 
-__all__ = ["ChatSession", "execute_python"]
+__all__ = ["ChatSession", "execute_terminal"]

--- a/src/chat.py
+++ b/src/chat.py
@@ -15,7 +15,7 @@ from .config import (
 from .db import Conversation, Message as DBMessage, User, _db, init_db
 from .log import get_logger
 from .schema import Msg
-from .tools import execute_python
+from .tools import execute_terminal
 
 _LOG = get_logger(__name__)
 
@@ -93,7 +93,7 @@ class ChatSession:
             self._model,
             messages=messages,
             think=think,
-            tools=[execute_python],
+            tools=[execute_terminal],
             options={"num_ctx": NUM_CTX},
         )
 
@@ -108,8 +108,8 @@ class ChatSession:
             return response
 
         for call in response.message.tool_calls:
-            if call.function.name == "execute_python":
-                result = execute_python(**call.function.arguments)
+            if call.function.name == "execute_terminal":
+                result = execute_terminal(**call.function.arguments)
             else:
                 continue
 


### PR DESCRIPTION
## Summary
- replace the sandboxed python tool with a terminal command tool
- update `ChatSession` to use the new terminal tool
- adjust public exports and the example script
- document the new behaviour in the README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_683c7d0e4eec8321bccb36103a2fdb64