### PR TITLE
Add Ollama install and model pulls to Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+# Python caches
+__pycache__/
+*.py[cod]
+
+# Git and GitHub
+.git
+.github
+
+# Development envs
+.env
+.venv
+venv/
+
+# Other ignored files
+*.db
+*.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,36 @@
+# syntax=docker/dockerfile:1
+
+FROM python:3.10-slim as base
+
+# Install system dependencies and Ollama
+RUN apt-get update && \
+    apt-get install -y curl gnupg && \
+    rm -rf /var/lib/apt/lists/* && \
+    curl -fsSL https://ollama.com/install.sh | sh
+
+# Create non-root user
+RUN useradd --create-home --uid 1000 botuser
+
+WORKDIR /app
+
+# Pull models at build time
+ENV OLLAMA_MODEL="qwen3"
+ENV OLLAMA_EMBEDDING_MODEL="nomic-embed-text"
+RUN ollama pull "$OLLAMA_MODEL" && ollama pull "$OLLAMA_EMBEDDING_MODEL"
+
+# Install Python dependencies
+COPY requirements.txt ./
+RUN pip install --no-cache-dir --upgrade pip && \
+    pip install --no-cache-dir -r requirements.txt
+
+# Copy application source
+COPY . .
+
+# Entrypoint script manages Ollama and the bot
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+USER botuser
+ENV PYTHONUNBUFFERED=1
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -19,3 +19,21 @@ python run.py
 ```
 
 The script will instruct the model to run a simple shell command and print the result. Conversations are automatically persisted to `chat.db` and are now associated with a user and session.
+
+## Docker
+
+A Dockerfile is provided to run the Discord bot along with an Ollama server. The image installs Ollama, pulls the LLM and embedding models, and starts both the server and the bot.
+
+Build the image:
+
+```bash
+docker build -t llm-discord-bot .
+```
+
+Run the container:
+
+```bash
+docker run -e DISCORD_TOKEN=your-token llm-discord-bot
+```
+
+The environment variables `OLLAMA_MODEL` and `OLLAMA_EMBEDDING_MODEL` can be set at build or run time to specify which models to download.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+set -e
+
+# Start Ollama server in the background
+ollama serve >/tmp/ollama.log 2>&1 &
+OLLAMA_PID=$!
+
+cleanup() {
+  kill "$OLLAMA_PID"
+}
+trap cleanup EXIT
+
+# Wait until the server is ready
+for i in $(seq 1 30); do
+  if curl -sf http://localhost:11434/api/tags >/dev/null 2>&1; then
+    break
+  fi
+  sleep 1
+done
+
+# Run the Discord bot
+exec python -m bot.discord_bot


### PR DESCRIPTION
## Summary
- install Ollama and pull models during the Docker build
- start Ollama and the Discord bot via entrypoint script
- document Docker usage and environment variables

## Testing
- `flake8` *(fails: command not found)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683ce6f1be1c8321b4d0c55c5d9c2ddf