### PR TITLE
Add document upload and update prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ database using Peewee. Histories are persisted per user and session so
 conversations can be resumed with context. One example tool is included:
 
 * **execute_terminal** – Executes a shell command inside a persistent Linux VM
-  with network access. Output from ``stdout`` and ``stderr`` is captured and
+  with network access. Use it to read uploaded documents under ``/data`` or run
+  other commands. Output from ``stdout`` and ``stderr`` is captured and
   returned. The VM is created when a chat session starts and reused for all
   subsequent tool calls.
 
@@ -21,6 +22,14 @@ python run.py
 ```
 
 The script will instruct the model to run a simple shell command and print the result. Conversations are automatically persisted to `chat.db` and are now associated with a user and session.
+
+Uploaded files are stored under the `uploads` directory and mounted inside the VM at `/data`. Call ``upload_document`` on the chat session to make a file available to the model:
+
+```python
+async with ChatSession() as chat:
+    path_in_vm = chat.upload_document("path/to/file.pdf")
+    reply = await chat.chat(f"Summarize {path_in_vm}")
+```
 
 ## Docker
 

--- a/run.py
+++ b/run.py
@@ -7,9 +7,8 @@ from src.chat import ChatSession
 
 async def _main() -> None:
     async with ChatSession(user="demo_user", session="demo_session") as chat:
-        answer = await chat.chat(
-            "check the processes running on the system"
-        )
+        doc_path = chat.upload_document("README.md")
+        answer = await chat.chat(f"List the first three lines of {doc_path}")
         print("\n>>>", answer)
 
 

--- a/src/config.py
+++ b/src/config.py
@@ -1,18 +1,23 @@
 from __future__ import annotations
 
 import os
+from pathlib import Path
 from typing import Final
 
 MODEL_NAME: Final[str] = os.getenv("OLLAMA_MODEL", "qwen3:1.7b")
-EMBEDDING_MODEL_NAME: Final[str] = os.getenv("OLLAMA_EMBEDDING_MODEL", "snowflake-arctic-embed:137m")   # unused for now
+EMBEDDING_MODEL_NAME: Final[str] = os.getenv(
+    "OLLAMA_EMBEDDING_MODEL", "snowflake-arctic-embed:137m"
+)  # unused for now
 OLLAMA_HOST: Final[str] = os.getenv("OLLAMA_HOST", "http://localhost:11434")
 MAX_TOOL_CALL_DEPTH: Final[int] = 5
 NUM_CTX: Final[int] = int(os.getenv("OLLAMA_NUM_CTX", "16000"))
+UPLOAD_DIR: Final[str] = os.getenv("UPLOAD_DIR", str(Path.cwd() / "uploads"))
 
 SYSTEM_PROMPT: Final[str] = (
     "You are a versatile AI assistant named Starlette able to orchestrate several tools to "
     "complete tasks. Plan your responses carefully and, when needed, call one "
     "or more tools consecutively to gather data, compute answers, or transform "
-    "information. Continue chaining tools until the user's request is fully "
-    "addressed and then deliver a concise, coherent final reply."
+    "information. Uploaded documents are available under /data and can be read "
+    "or modified using the execute_terminal tool. Continue chaining tools until "
+    "the user's request is fully addressed and then deliver a concise, coherent final reply."
 )

--- a/src/db.py
+++ b/src/db.py
@@ -46,12 +46,22 @@ class Message(BaseModel):
     created_at = DateTimeField(default=datetime.utcnow)
 
 
+class Document(BaseModel):
+    id = AutoField()
+    user = ForeignKeyField(User, backref="documents")
+    file_path = CharField()
+    original_name = CharField()
+    created_at = DateTimeField(default=datetime.utcnow)
+
+
 __all__ = [
     "_db",
     "User",
     "Conversation",
     "Message",
+    "Document",
     "reset_history",
+    "add_document",
 ]
 
 
@@ -59,7 +69,7 @@ def init_db() -> None:
     """Initialise the database and create tables if they do not exist."""
     if _db.is_closed():
         _db.connect()
-    _db.create_tables([User, Conversation, Message])
+    _db.create_tables([User, Conversation, Message, Document])
 
 
 def reset_history(username: str, session_name: str) -> int:
@@ -79,3 +89,12 @@ def reset_history(username: str, session_name: str) -> int:
     if not Conversation.select().where(Conversation.user == user).exists():
         user.delete_instance()
     return deleted
+
+
+def add_document(username: str, file_path: str, original_name: str) -> Document:
+    """Record an uploaded document and return the created entry."""
+
+    init_db()
+    user, _ = User.get_or_create(username=username)
+    doc = Document.create(user=user, file_path=file_path, original_name=original_name)
+    return doc

--- a/src/tools.py
+++ b/src/tools.py
@@ -20,7 +20,7 @@ def set_vm(vm: LinuxVM | None) -> None:
 def execute_terminal(command: str) -> str:
     """
     Execute a shell command in a Linux terminal.
-    Use this tool to run various commands.
+    Use this tool to inspect uploaded documents under ``/data`` or run other commands.
 
     The command is executed with network access enabled. Output from both
     ``stdout`` and ``stderr`` is captured and returned. Commands are killed if
@@ -29,7 +29,7 @@ def execute_terminal(command: str) -> str:
     timeout = 2
     if not command:
         return "No command provided."
-    
+
     if _VM:
         try:
             return _VM.execute(command, timeout=timeout)

--- a/src/vm.py
+++ b/src/vm.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 import subprocess
 import uuid
+from pathlib import Path
+
+from .config import UPLOAD_DIR
 
 from .log import get_logger
 
@@ -11,10 +14,14 @@ _LOG = get_logger(__name__)
 class LinuxVM:
     """Manage a lightweight Linux VM using Docker."""
 
-    def __init__(self, image: str = "ubuntu:latest") -> None:
+    def __init__(
+        self, image: str = "ubuntu:latest", host_dir: str = UPLOAD_DIR
+    ) -> None:
         self._image = image
         self._name = f"chat-vm-{uuid.uuid4().hex[:8]}"
         self._running = False
+        self._host_dir = Path(host_dir)
+        self._host_dir.mkdir(parents=True, exist_ok=True)
 
     def start(self) -> None:
         """Start the VM if it is not already running."""
@@ -36,6 +43,8 @@ class LinuxVM:
                     "-d",
                     "--name",
                     self._name,
+                    "-v",
+                    f"{self._host_dir}:/data",
                     self._image,
                     "sleep",
                     "infinity",


### PR DESCRIPTION
## Summary
- support storing uploaded documents via `ChatSession.upload_document`
- mount an upload directory inside the VM
- mention document use in system prompt and `execute_terminal` description
- show document usage example

## Testing
- `black --check .`
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841d32ff23483219426aeee5d63c4cd