### PR TITLE
Remove persisted system prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,9 @@ conversations can be resumed with context. One example tool is included:
   returned. The VM is created when a chat session starts and reused for all
   subsequent tool calls.
 
-The application now injects a system prompt that instructs the model to chain
-multiple tools when required. This prompt ensures the assistant can orchestrate
+The application injects a system prompt on each request that instructs the
+model to chain multiple tools when required. This prompt is **not** stored in
+the chat history but is provided at runtime so the assistant can orchestrate
 tool calls in sequence to satisfy the user's request.
 
 ## Usage


### PR DESCRIPTION
## Summary
- do not store system prompts in the database
- inject system prompt at runtime
- update documentation accordingly

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile src/*.py run.py`
- `python run.py` *(fails: Failed to start VM: [Errno 2] No such file or directory: 'docker')*

------
https://chatgpt.com/codex/tasks/task_e_684216d13f5483218d5539d037eeb9e0