### PR TITLE
Add HTTP API for LLM chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,18 @@ When using the Discord bot, attach one or more text files to a message to
 upload them automatically. The bot responds with the location of each document
 inside the VM so they can be referenced in subsequent prompts.
 
+## API Server
+
+An HTTP API is provided using FastAPI. Run the server with:
+
+```bash
+python server.py
+```
+
+Send a POST request to `/chat` with the fields `user`, `session` and `prompt` to
+receive the assistant's reply. Conversation history is persisted in
+`chat.db`. Use the `/reset` endpoint to clear previous messages for a session.
+
 ## Docker
 
 A Dockerfile is provided to run the Discord bot along with an Ollama server. The image installs Ollama, pulls the LLM and embedding models, and starts both the server and the bot.

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ peewee
 discord.py
 colorama
 python-dotenv
+fastapi
+uvicorn

--- a/server.py
+++ b/server.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+import uvicorn
+
+from src.api import create_app
+
+
+def main() -> None:
+    uvicorn.run(create_app(), host="0.0.0.0", port=8000)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual start
+    main()

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,5 +1,6 @@
 from .chat import ChatSession
 from .tools import execute_terminal, set_vm
 from .vm import LinuxVM
+from .api import create_app
 
-__all__ = ["ChatSession", "execute_terminal", "set_vm", "LinuxVM"]
+__all__ = ["ChatSession", "execute_terminal", "set_vm", "LinuxVM", "create_app"]

--- a/src/api/__init__.py
+++ b/src/api/__init__.py
@@ -1,0 +1,3 @@
+from .app import create_app
+
+__all__ = ["create_app"]

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from fastapi import FastAPI
+
+from .router import router
+
+__all__ = ["create_app"]
+
+
+def create_app() -> FastAPI:
+    app = FastAPI(title="LLM Chat API", version="1.0.0")
+    app.include_router(router)
+    return app

--- a/src/api/models.py
+++ b/src/api/models.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+__all__ = ["ChatRequest", "ChatResponse", "ResetRequest", "ResetResponse"]
+
+class ChatRequest(BaseModel):
+    user: str = Field(..., example="default")
+    session: str = Field(..., example="default")
+    prompt: str = Field(..., min_length=1, example="Hello")
+
+class ChatResponse(BaseModel):
+    reply: str
+
+class ResetRequest(BaseModel):
+    user: str
+    session: str
+
+class ResetResponse(BaseModel):
+    removed: int

--- a/src/api/router.py
+++ b/src/api/router.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException, status
+
+from .models import ChatRequest, ChatResponse, ResetRequest, ResetResponse
+from ..chat import ChatSession
+from ..db import reset_history
+from ..log import get_logger
+
+router = APIRouter()
+log = get_logger(__name__)
+
+
+@router.post("/chat", response_model=ChatResponse, status_code=status.HTTP_200_OK)
+async def chat_endpoint(payload: ChatRequest) -> ChatResponse:
+    log.debug("chat request user=%s session=%s", payload.user, payload.session)
+    async with ChatSession(user=payload.user, session=payload.session) as chat:
+        try:
+            reply = await chat.chat(payload.prompt)
+        except Exception as exc:  # pragma: no cover - runtime errors
+            log.exception("chat processing failed")
+            raise HTTPException(status_code=500, detail=str(exc)) from exc
+    return ChatResponse(reply=reply)
+
+
+@router.post("/reset", response_model=ResetResponse, status_code=status.HTTP_200_OK)
+async def reset_endpoint(payload: ResetRequest) -> ResetResponse:
+    removed = reset_history(payload.user, payload.session)
+    return ResetResponse(removed=removed)


### PR DESCRIPTION
## Summary
- implement FastAPI app for chat sessions
- expose `/chat` and `/reset` endpoints
- add server runner script
- update README with API instructions
- include FastAPI and uvicorn in dependencies

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6842e73dcd408321affe6c6730adf0ad