### PR TITLE
Enhance session management utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,14 @@ async with ChatSession() as chat:
 When using the Discord bot, attach one or more text files to a message to
 upload them automatically. The bot responds with the location of each document
 inside the VM so they can be referenced in subsequent prompts.
+
+## Managing Sessions and Documents
+
+`ChatSession` provides helpers to make it easier to work with multiple sessions
+and uploaded files:
+
+* `list_sessions()` – return all session names for the current user.
+* `list_uploaded_documents()` – show the paths of documents uploaded by the user.
+* `reset_history()` – clear a session's conversation history.
+
+These methods allow you to inspect and manage chat data programmatically.

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,6 +1,5 @@
 from .chat import ChatSession
 from .tools import execute_terminal, set_vm
 from .vm import LinuxVM
-from .api import create_app
 
-__all__ = ["ChatSession", "execute_terminal", "set_vm", "LinuxVM", "create_app"]
+__all__ = ["ChatSession", "execute_terminal", "set_vm", "LinuxVM"]

--- a/src/chat.py
+++ b/src/chat.py
@@ -23,6 +23,9 @@ from .db import (
     _db,
     init_db,
     add_document,
+    list_documents,
+    list_sessions,
+    reset_history,
 )
 from .log import get_logger
 from .schema import Msg
@@ -181,3 +184,24 @@ class ChatSession:
             self._messages, response, self._conversation
         )
         return final_resp.message.content
+
+    def reset_history(self) -> int:
+        """Clear conversation history and start fresh."""
+
+        deleted = reset_history(self._user.username, self._conversation.session_name)
+        self._conversation, _ = Conversation.get_or_create(
+            user=self._user, session_name=self._conversation.session_name
+        )
+        self._messages = []
+        return deleted
+
+    def list_uploaded_documents(self) -> list[str]:
+        """Return file paths of documents uploaded by the user."""
+
+        docs = list_documents(self._user.username)
+        return [d.file_path for d in docs]
+
+    def list_sessions(self) -> list[str]:
+        """List all session names for the current user."""
+
+        return list_sessions(self._user.username)

--- a/src/db.py
+++ b/src/db.py
@@ -62,6 +62,8 @@ __all__ = [
     "Document",
     "reset_history",
     "add_document",
+    "list_sessions",
+    "list_documents",
 ]
 
 
@@ -98,3 +100,28 @@ def add_document(username: str, file_path: str, original_name: str) -> Document:
     user, _ = User.get_or_create(username=username)
     doc = Document.create(user=user, file_path=file_path, original_name=original_name)
     return doc
+
+
+def list_sessions(username: str) -> list[str]:
+    """Return all session names for ``username``."""
+
+    init_db()
+    try:
+        user = User.get(User.username == username)
+    except User.DoesNotExist:
+        return []
+
+    q = Conversation.select(Conversation.session_name).where(Conversation.user == user)
+    return [conv.session_name for conv in q]
+
+
+def list_documents(username: str) -> list[Document]:
+    """Return all documents uploaded by ``username``."""
+
+    init_db()
+    try:
+        user = User.get(User.username == username)
+    except User.DoesNotExist:
+        return []
+
+    return list(Document.select().where(Document.user == user))


### PR DESCRIPTION
## Summary
- clean up exports after removing API code
- expose additional helpers in `db`
- add document/session management methods to `ChatSession`
- document the new helpers in the README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python run.py` *(fails: ModuleNotFoundError: No module named 'ollama')*

------
https://chatgpt.com/codex/tasks/task_e_6842edcd8dd88321b1a7b31ab411cd33