### PR TITLE
Add Discord bot integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,20 @@ async with ChatSession() as chat:
 When using the Discord bot, attach one or more text files to a message to
 upload them automatically. The bot responds with the location of each document
 inside the VM so they can be referenced in subsequent prompts.
+
+## Discord Bot
+
+Create a `.env` file with your Discord token:
+
+```bash
+DISCORD_TOKEN="your-token"
+```
+
+Then start the bot:
+
+```bash
+python -m bot.discord_bot
+```
+
+Any attachments sent to the bot are uploaded to the VM and the bot replies with
+their paths so they can be used in later messages.

--- a/bot/__init__.py
+++ b/bot/__init__.py
@@ -1,0 +1,5 @@
+"""Discord bot package."""
+
+from .discord_bot import main
+
+__all__ = ["main"]

--- a/bot/discord_bot.py
+++ b/bot/discord_bot.py
@@ -1,0 +1,95 @@
+import logging
+import os
+import shutil
+import tempfile
+from pathlib import Path
+
+import discord
+from discord.ext import commands
+from dotenv import load_dotenv
+
+from src.chat import ChatSession
+from src.db import reset_history
+from src.log import get_logger
+
+_LOG = get_logger(__name__, level=logging.INFO)
+
+
+def _create_bot() -> commands.Bot:
+    intents = discord.Intents.default()
+    intents.messages = True
+    intents.message_content = True
+    return commands.Bot(command_prefix="!", intents=intents)
+
+
+bot = _create_bot()
+
+
+@bot.event
+async def on_ready() -> None:
+    _LOG.info("Logged in as %s", bot.user)
+
+
+@bot.command(name="reset")
+async def reset(ctx: commands.Context) -> None:
+    deleted = reset_history(str(ctx.author.id), str(ctx.channel.id))
+    await ctx.reply(f"Chat history cleared ({deleted} messages deleted).")
+
+
+async def _handle_attachments(chat: ChatSession, message: discord.Message) -> list[tuple[str, str]]:
+    if not message.attachments:
+        return []
+
+    uploaded: list[tuple[str, str]] = []
+    tmpdir = Path(tempfile.mkdtemp(prefix="discord_upload_"))
+    try:
+        for attachment in message.attachments:
+            dest = tmpdir / attachment.filename
+            await attachment.save(dest)
+            vm_path = chat.upload_document(str(dest))
+            uploaded.append((attachment.filename, vm_path))
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+    return uploaded
+
+
+@bot.event
+async def on_message(message: discord.Message) -> None:
+    if message.author.bot:
+        return
+
+    await bot.process_commands(message)
+    if message.content.startswith("!"):
+        return
+
+    async with ChatSession(user=str(message.author.id), session=str(message.channel.id)) as chat:
+        docs = await _handle_attachments(chat, message)
+        if docs:
+            info = "\n".join(f"{name} -> {path}" for name, path in docs)
+            await message.channel.send(f"Uploaded:\n{info}")
+
+        if message.content.strip():
+            try:
+                reply = await chat.chat(message.content)
+            except Exception as exc:  # pragma: no cover - runtime errors
+                _LOG.error("Failed to process message: %s", exc)
+                await message.channel.send(f"Error: {exc}")
+            else:
+                await message.channel.send(reply)
+
+
+def main() -> None:
+    load_dotenv()
+    token = os.getenv("DISCORD_TOKEN")
+    if not token:
+        raise RuntimeError("DISCORD_TOKEN environment variable not set")
+
+    bot.run(token)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except KeyboardInterrupt:  # pragma: no cover - manual exit
+        pass

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,6 +1,5 @@
 from .chat import ChatSession
 from .tools import execute_terminal, set_vm
 from .vm import LinuxVM
-from .api import create_app
 
-__all__ = ["ChatSession", "execute_terminal", "set_vm", "LinuxVM", "create_app"]
+__all__ = ["ChatSession", "execute_terminal", "set_vm", "LinuxVM"]


### PR DESCRIPTION
## Summary
- add new `bot` package with a Discord bot implementation
- allow uploading message attachments to the VM and chatting through `ChatSession`
- remove missing `create_app` import from `src/__init__.py`
- document running the bot in the README

## Testing
- `python -m pip install -r requirements.txt`
- `python -m bot.discord_bot` *(fails: `DISCORD_TOKEN` not set)*

------
https://chatgpt.com/codex/tasks/task_e_6842f2ee66b88321b3c9cbe0f704c46d