### PR TITLE
Fix CancelledError handling in tool execution

### DIFF
--- a/src/chat.py
+++ b/src/chat.py
@@ -173,7 +173,7 @@ class ChatSession:
                     follow_task.cancel()
                     try:
                         await follow_task
-                    except Exception:
+                    except asyncio.CancelledError:
                         pass
                     result = await exec_task
                     messages.append(


### PR DESCRIPTION
## Summary
- handle `asyncio.CancelledError` when cancelling follow-up chat requests

## Testing
- `pip install -r requirements.txt`
- `python -m compileall -q src`

------
https://chatgpt.com/codex/tasks/task_e_6843762adbd48321a1d35ab614112297