### PR TITLE
Enable async message streaming with tool priority

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ Uploaded files are stored under the `uploads` directory and mounted inside the V
 ```python
 async with ChatSession() as chat:
     path_in_vm = chat.upload_document("path/to/file.pdf")
-    reply = await chat.chat(f"Summarize {path_in_vm}")
+    async for part in chat.chat_stream(f"Summarize {path_in_vm}"):
+        print(part)
 ```
 
 When using the Discord bot, attach one or more text files to a message to

--- a/bot/discord_bot.py
+++ b/bot/discord_bot.py
@@ -71,12 +71,11 @@ async def on_message(message: discord.Message) -> None:
 
         if message.content.strip():
             try:
-                reply = await chat.chat(message.content)
+                async for part in chat.chat_stream(message.content):
+                    await message.reply(part, mention_author=False)
             except Exception as exc:  # pragma: no cover - runtime errors
                 _LOG.error("Failed to process message: %s", exc)
                 await message.reply(f"Error: {exc}", mention_author=False)
-            else:
-                await message.reply(reply, mention_author=False)
 
 
 def main() -> None:

--- a/run.py
+++ b/run.py
@@ -10,8 +10,8 @@ async def _main() -> None:
         doc_path = chat.upload_document("test.txt")
         # print(f"Document uploaded to VM at: {doc_path}")
         # answer = await chat.chat(f"Remove all contents of test.txt and add the text 'Hello, World!' to it.")
-        answer = await chat.chat("What is in /data directory?")
-        print("\n>>>", answer)
+        async for resp in chat.chat_stream("What is in /data directory?"):
+            print("\n>>>", resp)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add async `chat_stream` for incremental responses
- track session state and running tool tasks
- prioritize tool output when racing with other generations
- update Discord bot and example script to consume message streams
- document streaming usage in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python run.py` *(fails: ModuleNotFoundError: No module named 'ollama')*

------
https://chatgpt.com/codex/tasks/task_e_6843802cb91483218d85d77d7aac24c8