### PR TITLE
Fix Discord bot message sending

### DIFF
--- a/bot/discord_bot.py
+++ b/bot/discord_bot.py
@@ -8,6 +8,8 @@ import discord
 from discord.ext import commands
 from dotenv import load_dotenv
 
+from .message_utils import send_reply
+
 from src.chat import ChatSession
 from src.db import reset_history
 from src.log import get_logger
@@ -65,15 +67,15 @@ async def on_message(message: discord.Message) -> None:
         docs = await _handle_attachments(chat, message)
         if docs:
             info = "\n".join(f"{name} -> {path}" for name, path in docs)
-            await message.reply(f"Uploaded:\n{info}", mention_author=False)
+            await send_reply(message, f"Uploaded:\n{info}", mention_author=False)
 
         if message.content.strip():
             try:
                 async for part in chat.chat_stream(message.content):
-                    await message.reply(part, mention_author=False)
+                    await send_reply(message, part, mention_author=False)
             except Exception as exc:  # pragma: no cover - runtime errors
                 _LOG.error("Failed to process message: %s", exc)
-                await message.reply(f"Error: {exc}", mention_author=False)
+                await send_reply(message, f"Error: {exc}", mention_author=False)
 
 
 def main() -> None:

--- a/bot/message_utils.py
+++ b/bot/message_utils.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from typing import Iterator
+
+import discord
+
+MAX_CONTENT_LENGTH = 2000
+
+
+def chunk_message(content: str, limit: int = MAX_CONTENT_LENGTH) -> Iterator[str]:
+    """Yield pieces of ``content`` each under ``limit`` characters."""
+    for i in range(0, len(content), limit):
+        yield content[i : i + limit]
+
+
+async def send_reply(
+    message: discord.Message, content: str, *, mention_author: bool = False
+) -> None:
+    """Reply to ``message`` with ``content``, splitting if needed."""
+    chunks = list(chunk_message(content))
+    if not chunks:
+        return
+
+    await message.reply(chunks[0], mention_author=mention_author)
+    for chunk in chunks[1:]:
+        await message.channel.send(chunk)


### PR DESCRIPTION
## Summary
- ensure large responses to Discord are split into chunks
- use new `send_reply` helper in the bot

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install -q -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_6843853a326883219394f003ec5e2ec8