### PR TITLE
Fix Discord bot not responding when no tool used

### DIFF
--- a/src/chat.py
+++ b/src/chat.py
@@ -141,6 +141,12 @@ class ChatSession:
         conversation: Conversation,
         depth: int = 0,
     ) -> AsyncIterator[ChatResponse]:
+        if not response.message.tool_calls:
+            if response.message.content:
+                yield response
+            async with self._lock:
+                self._state = "idle"
+            return
         while depth < MAX_TOOL_CALL_DEPTH and response.message.tool_calls:
             for call in response.message.tool_calls:
                 if call.function.name != "execute_terminal":


### PR DESCRIPTION
## Summary
- return a chat response when no tools are used

## Testing
- `pip install -q -r requirements.txt`
- `python run.py` *(fails: docker not found)*

------
https://chatgpt.com/codex/tasks/task_e_68438a98737c832191e1c87ac86790a4