### PR TITLE
Improve session concurrency

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@ conversations can be resumed with context. One example tool is included:
   responding while they execute. The VM is created when a chat session starts
   and reused for all subsequent tool calls.
 
+Sessions share state through an in-memory registry so that only one generation
+can run at a time. Messages sent while a response is being produced are
+ignored unless the assistant is waiting for a tool result—in that case the
+pending response is cancelled and replaced with the new request.
+
 The application injects a robust system prompt on each request. The prompt
 guides the model to plan tool usage, execute commands sequentially and
 verify results before replying. It is **not** stored in the chat history but is


### PR DESCRIPTION
## Summary
- maintain shared session state so overlapping chats can't run concurrently
- document the new session registry

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68438db9eeb0832198ad2ef0c2526670