### PR TITLE
Add FastAPI API for document management

### DIFF
--- a/src/api.py
+++ b/src/api.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from typing import List
+from datetime import datetime
+
+from fastapi import FastAPI, UploadFile, File, HTTPException
+from pydantic import BaseModel
+from fastapi.responses import PlainTextResponse
+
+from .document_service import (
+    save_document,
+    list_documents,
+    get_document,
+    read_content,
+)
+from .log import get_logger
+
+
+class DocumentInfo(BaseModel):
+    id: int
+    original_name: str
+    file_path: str
+    created_at: datetime
+
+    class Config:
+        from_attributes = True
+
+
+class DocumentDetail(DocumentInfo):
+    content: str
+
+
+def create_app() -> FastAPI:
+    app = FastAPI(title="LLM Backend API")
+    log = get_logger(__name__)
+
+    @app.post("/users/{username}/documents", response_model=DocumentInfo)
+    async def upload(username: str, file: UploadFile = File(...)) -> DocumentInfo:
+        log.info("Uploading document %s for %s", file.filename, username)
+        doc = save_document(username, file)
+        return DocumentInfo.model_validate(doc.__data__)
+
+    @app.get("/users/{username}/documents", response_model=List[DocumentInfo])
+    async def list_docs(username: str) -> List[DocumentInfo]:
+        docs = list_documents(username)
+        return [DocumentInfo.model_validate(d.__data__) for d in docs]
+
+    @app.get("/users/{username}/documents/{doc_id}", response_model=DocumentDetail)
+    async def inspect(username: str, doc_id: int) -> DocumentDetail:
+        doc = get_document(username, doc_id)
+        if not doc:
+            raise HTTPException(status_code=404, detail="Document not found")
+        content = read_content(doc)
+        data = DocumentDetail.model_validate(doc.__data__)
+        data.content = content
+        return data
+
+    @app.get("/users/{username}/documents/{doc_id}/raw", response_class=PlainTextResponse)
+    async def download(username: str, doc_id: int) -> PlainTextResponse:
+        doc = get_document(username, doc_id)
+        if not doc:
+            raise HTTPException(status_code=404, detail="Document not found")
+        return PlainTextResponse(read_content(doc))
+
+    return app
+
+
+app = create_app()
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/src/document_service.py
+++ b/src/document_service.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from pathlib import Path
+import shutil
+from typing import List, Optional
+
+from fastapi import UploadFile
+
+from .config import UPLOAD_DIR
+from .db import Document, User, init_db
+
+
+def _ensure_user_dir(username: str) -> Path:
+    path = Path(UPLOAD_DIR) / username
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def save_document(username: str, file: UploadFile) -> Document:
+    """Persist an uploaded file and return its database entry."""
+    init_db()
+    user, _ = User.get_or_create(username=username)
+    dest_dir = _ensure_user_dir(username)
+    dest = dest_dir / file.filename
+    with dest.open('wb') as buffer:
+        shutil.copyfileobj(file.file, buffer)
+    doc = Document.create(user=user, file_path=str(dest), original_name=file.filename)
+    return doc
+
+
+def list_documents(username: str) -> List[Document]:
+    """Return all documents for ``username`` sorted by creation time."""
+    init_db()
+    try:
+        user = User.get(User.username == username)
+    except User.DoesNotExist:
+        return []
+    docs = Document.select().where(Document.user == user).order_by(Document.created_at)
+    return list(docs)
+
+
+def get_document(username: str, doc_id: int) -> Optional[Document]:
+    """Retrieve a single document for ``username`` by id."""
+    init_db()
+    try:
+        user = User.get(User.username == username)
+    except User.DoesNotExist:
+        return None
+    try:
+        return Document.get(Document.id == doc_id, Document.user == user)
+    except Document.DoesNotExist:
+        return None
+
+
+def read_content(doc: Document) -> str:
+    """Read and return the text content of ``doc``. Errors yield empty string."""
+    try:
+        return Path(doc.file_path).read_text(encoding='utf-8', errors='replace')
+    except Exception:
+        return ''


### PR DESCRIPTION
## Summary
- add `document_service` for managing uploads in database and storage
- implement `FastAPI` app with endpoints to upload, list and inspect documents

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68444adb74f88321bc1de5ff74cec923