### PR TITLE
Refactor API modules into dedicated package

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -1,0 +1,19 @@
+"""Public interface for the API package."""
+
+from .api import create_app, app
+from .document_service import (
+    save_document,
+    list_documents,
+    get_document,
+    read_content,
+)
+
+__all__ = [
+    "create_app",
+    "app",
+    "save_document",
+    "list_documents",
+    "get_document",
+    "read_content",
+]
+

--- a/api/api.py
+++ b/api/api.py
@@ -13,7 +13,7 @@ from .document_service import (
     get_document,
     read_content,
 )
-from .log import get_logger
+from src.log import get_logger
 
 
 class DocumentInfo(BaseModel):

--- a/api/document_service.py
+++ b/api/document_service.py
@@ -6,8 +6,8 @@ from typing import List, Optional
 
 from fastapi import UploadFile
 
-from .config import UPLOAD_DIR
-from .db import Document, User, init_db
+from src.config import UPLOAD_DIR
+from src.db import Document, User, init_db
 
 
 def _ensure_user_dir(username: str) -> Path:


### PR DESCRIPTION
## Summary
- move `api.py` and `document_service.py` into new top-level `api` package
- update imports to use the new package location
- expose API helpers through `api/__init__.py`

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68444d01cc988321807a63fa66508e8f