### PR TITLE
Improve system prompt and tool description

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,13 @@ database using Peewee. Histories are persisted per user and session so
 conversations can be resumed with context. One example tool is included:
 
 * **execute_terminal** – Executes a shell command inside a persistent Linux VM
-  with network access. Use it to read uploaded documents under ``/data`` or run
-  other commands. Output from ``stdout`` and ``stderr`` is captured and
-  returned. Commands run asynchronously so the assistant can continue
-  responding while they execute. The VM is created when a chat session starts
-  and reused for all subsequent tool calls.
+  with network access. Use it to read uploaded documents under ``/data``, fetch
+  web content via tools like ``curl`` or run any other commands. The assistant
+  must invoke this tool to search online when unsure about a response. Output
+  from ``stdout`` and ``stderr`` is captured and returned. Commands run
+  asynchronously so the assistant can continue responding while they execute.
+  The VM is created when a chat session starts and reused for all subsequent
+  tool calls.
 
 Sessions share state through an in-memory registry so that only one generation
 can run at a time. Messages sent while a response is being produced are
@@ -19,9 +21,11 @@ pending response is cancelled and replaced with the new request.
 
 The application injects a robust system prompt on each request. The prompt
 guides the model to plan tool usage, execute commands sequentially and
-verify results before replying. It is **not** stored in the chat history but is
-provided at runtime so the assistant can orchestrate tool calls in sequence to
-fulfil the user's request reliably.
+verify results before replying. When the assistant is uncertain, it is directed
+to search the internet with ``execute_terminal`` before giving a final answer.
+The prompt is **not** stored in the chat history but is provided at runtime so
+the assistant can orchestrate tool calls in sequence to fulfil the user's
+request reliably.
 
 ## Usage
 

--- a/src/config.py
+++ b/src/config.py
@@ -19,7 +19,9 @@ SYSTEM_PROMPT: Final[str] = (
     "tool returns its result you will receive a tool message and must continue from "
     "there. If the result arrives before your interim reply is complete, cancel the "
     "reply and incorporate the tool output instead. Uploaded files live under /data "
-    "and are accessible via the execute_terminal tool. Continue using tools until "
-    "you have gathered everything required to produce an accurate answer, then craft "
-    "a clear and precise final response that fully addresses the request."
+    "and are accessible via the execute_terminal tool. When you are unsure about any "
+    "detail, you must use execute_terminal to search the internet or inspect files "
+    "before answering. Continue using tools until you have gathered everything "
+    "required to produce an accurate answer, then craft a clear and precise final "
+    "response that fully addresses the request."
 )

--- a/src/tools.py
+++ b/src/tools.py
@@ -21,7 +21,10 @@ def set_vm(vm: LinuxVM | None) -> None:
 def execute_terminal(command: str) -> str:
     """
     Execute a shell command in a Ubuntu terminal.
-    Use this tool to inspect uploaded documents under ``/data`` or run other commands.
+    Use this tool to inspect uploaded documents under ``/data``, fetch web
+    content with utilities like ``curl`` or ``wget`` and run other commands.
+    The assistant must call this tool to search the internet whenever unsure
+    about any detail.
 
     The command is executed with network access enabled. Output from both
     ``stdout`` and ``stderr`` is captured and returned. Commands are killed if


### PR DESCRIPTION
## Summary
- clarify `execute_terminal` tool usage in README
- add guidance in README that the system prompt instructs lookup when unsure
- update system prompt to require searching the internet when uncertain
- update tool docstring with lookup requirement

## Testing
- `pip install -r requirements.txt`
- `python run.py` *(fails: Failed to start VM: [Errno 2] No such file or directory: 'docker')*

------
https://chatgpt.com/codex/tasks/task_e_6844a029dd788321be7a9f11fd763bfb