### PR TITLE
Persist terminal commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,9 @@ conversations can be resumed with context. One example tool is included:
   with network access. Use it to read uploaded documents under ``/data``, fetch
   web content via tools like ``curl`` or run any other commands. The assistant
   must invoke this tool to search online when unsure about a response. Output
-  from ``stdout`` and ``stderr`` is captured and returned. Commands run
-  asynchronously so the assistant can continue responding while they execute.
+  from ``stdout`` and ``stderr`` is captured when available. Commands are
+  launched in the background with no timeout so the assistant can continue
+  responding while they execute.
   The VM is created when a chat session starts and reused for all subsequent
   tool calls.
 

--- a/src/tools.py
+++ b/src/tools.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 __all__ = ["execute_terminal", "execute_terminal_async", "set_vm"]
 
 import subprocess
+import os
 from typing import Optional
 import asyncio
 
@@ -26,37 +27,31 @@ def execute_terminal(command: str) -> str:
     The assistant must call this tool to search the internet whenever unsure
     about any detail.
 
-    The command is executed with network access enabled. Output from both
-    ``stdout`` and ``stderr`` is captured and returned. Commands are killed if
-    they exceed 30 seconds.
+    The command is executed with network access enabled. It runs in the
+    background without a timeout so the assistant can continue responding
+    while the command executes.
     """
-    timeout = 30
     if not command:
         return "No command provided."
 
     if _VM:
         try:
-            return _VM.execute(command, timeout=timeout)
+            return _VM.execute(command, detach=True)
         except Exception as exc:  # pragma: no cover - unforeseen errors
             return f"Failed to execute command in VM: {exc}"
 
     try:
-        completed = subprocess.run(
+        subprocess.Popen(
             command,
             shell=True,
-            capture_output=True,
-            text=True,
-            timeout=timeout,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+            env=os.environ.copy(),
         )
-    except subprocess.TimeoutExpired as exc:
-        return f"Command timed out after {timeout}s: {exc.cmd}"
+        return "Command started in background."
     except Exception as exc:  # pragma: no cover - unforeseen errors
         return f"Failed to execute command: {exc}"
-
-    output = completed.stdout
-    if completed.stderr:
-        output = f"{output}\n{completed.stderr}" if output else completed.stderr
-    return output.strip()
 
 
 async def execute_terminal_async(command: str) -> str:


### PR DESCRIPTION
## Summary
- run execute_terminal commands detached from LLM generation
- add detach option in LinuxVM
- update documentation

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`
- `python run.py` *(fails: `RuntimeError: Failed to start VM: [Errno 2] No such file or directory: 'docker'`)*

------
https://chatgpt.com/codex/tasks/task_e_6844d4581fe48321873552f195294614