### PR TITLE
Refine system prompt for plain-language responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,10 @@ verify results before replying. When the assistant is uncertain, it is directed
 to search the internet with ``execute_terminal`` before giving a final answer.
 The prompt is **not** stored in the chat history but is provided at runtime so
 the assistant can orchestrate tool calls in sequence to fulfil the user's
-request reliably. If a user message ends with ``/think`` it simply selects an
-internal reasoning mode and should be stripped from the prompt before
-processing.
+request reliably. It also directs the assistant to avoid technical jargon so
+responses are easy for anyone to understand. If a user message ends with
+``/think`` it simply selects an internal reasoning mode and should be stripped
+from the prompt before processing.
 
 ## Usage
 

--- a/src/config.py
+++ b/src/config.py
@@ -31,7 +31,9 @@ SYSTEM_PROMPT: Final[str] = (
     "execute_terminal to search the internet or inspect files before answering. "
     "Continue using tools until you have gathered everything required to produce "
     "an accurate answer, then craft a clear and precise final response that fully "
-    "addresses the request. Assume the user is unfamiliar with computers, so take "
-    "the initiative to run terminal commands yourself and minimize the steps the "
-    "user must perform."
+    "addresses the request. Always assume the user has no knowledge of computers "
+    "or programming, so take the initiative to run terminal commands yourself and "
+    "minimize the steps the user must perform. When replying, avoid technical "
+    "jargon entirely. Speak in plain language that anyone can understand, "
+    "explaining concepts as simply as possible."
 )


### PR DESCRIPTION
## Summary
- expand the system prompt so all answers use simple language
- document the plain-language instruction in the README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844e8cf0f5c83219fc3d2e822ab6849