### PR TITLE
Add Windows-friendly CLI and session list endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ uvicorn src.api:app --host 0.0.0.0 --port 8000
 
 - ``POST /chat/stream`` – Stream the assistant's response as plain text.
 - ``POST /upload`` – Upload a document so it can be referenced in chats.
+- ``GET /sessions/{user}`` – List available session names for ``user``.
 
 Example request:
 
@@ -142,3 +143,16 @@ curl -N -X POST http://localhost:8000/chat/stream \
      -H 'Content-Type: application/json' \
      -d '{"user":"demo","session":"default","prompt":"Hello"}'
 ```
+
+## CLI
+
+An interactive command line interface is provided for Windows and other
+platforms. Install the dependencies and run:
+
+```bash
+python -m src.cli --user yourname
+```
+
+The tool lists your existing chat sessions and lets you select one or create a
+new session. Type messages and the assistant's streamed replies will appear
+immediately. Enter ``exit`` or press ``Ctrl+D`` to quit.

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,5 @@ python-dotenv
 fastapi
 uvicorn
 python-multipart
+httpx
+typer

--- a/src/api.py
+++ b/src/api.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 from .chat import ChatSession
 from .log import get_logger
+from .db import list_sessions
 
 
 _LOG = get_logger(__name__)
@@ -57,6 +58,10 @@ def create_app() -> FastAPI:
                 except OSError:
                     pass
         return {"path": vm_path}
+
+    @app.get("/sessions/{user}")
+    async def list_user_sessions(user: str):
+        return {"sessions": list_sessions(user)}
 
     @app.get("/health")
     async def health():

--- a/src/cli.py
+++ b/src/cli.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import asyncio
+from typing import AsyncIterator
+
+import httpx
+import typer
+from colorama import Fore, Style, init
+
+
+API_URL = "http://localhost:8000"
+
+app = typer.Typer(add_completion=False, help="Interact with the LLM backend API")
+
+
+async def _get_sessions(user: str, server: str) -> list[str]:
+    async with httpx.AsyncClient(base_url=server) as client:
+        resp = await client.get(f"/sessions/{user}")
+        resp.raise_for_status()
+        data = resp.json()
+        return data.get("sessions", [])
+
+
+async def _stream_chat(
+    user: str, session: str, prompt: str, server: str
+) -> AsyncIterator[str]:
+    async with httpx.AsyncClient(base_url=server, timeout=None) as client:
+        async with client.stream(
+            "POST",
+            "/chat/stream",
+            json={"user": user, "session": session, "prompt": prompt},
+        ) as resp:
+            resp.raise_for_status()
+            async for line in resp.aiter_lines():
+                if line:
+                    yield line
+
+
+async def _chat_loop(user: str, server: str) -> None:
+    init(autoreset=True)
+    sessions = await _get_sessions(user, server)
+    session = "default"
+    if sessions:
+        typer.echo("Existing sessions:")
+        for idx, name in enumerate(sessions, 1):
+            typer.echo(f"  {idx}. {name}")
+        choice = typer.prompt(
+            "Select session number or enter new name", default=str(len(sessions))
+        )
+        if choice.isdigit() and 1 <= int(choice) <= len(sessions):
+            session = sessions[int(choice) - 1]
+        else:
+            session = choice.strip() or session
+    else:
+        session = typer.prompt("Session name", default=session)
+
+    typer.echo(
+        f"Chatting as {Fore.GREEN}{user}{Style.RESET_ALL} in session '{session}'"
+    )
+
+    while True:
+        try:
+            msg = typer.prompt(f"{Fore.CYAN}You{Style.RESET_ALL}")
+        except EOFError:
+            break
+        if msg.strip().lower() in {"exit", "quit"}:
+            break
+        async for part in _stream_chat(user, session, msg, server):
+            typer.echo(f"{Fore.YELLOW}{part}{Style.RESET_ALL}")
+
+
+@app.callback(invoke_without_command=True)
+def main(
+    user: str = typer.Option("default", "--user", "-u"),
+    server: str = typer.Option(API_URL, "--server", "-s"),
+) -> None:
+    """Start an interactive chat session."""
+
+    asyncio.run(_chat_loop(user, server))
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution
+    app()

--- a/src/db.py
+++ b/src/db.py
@@ -61,6 +61,7 @@ __all__ = [
     "Message",
     "Document",
     "reset_history",
+    "list_sessions",
     "add_document",
 ]
 
@@ -98,3 +99,14 @@ def add_document(username: str, file_path: str, original_name: str) -> Document:
     user, _ = User.get_or_create(username=username)
     doc = Document.create(user=user, file_path=file_path, original_name=original_name)
     return doc
+
+
+def list_sessions(username: str) -> list[str]:
+    """Return all session names for the given ``username``."""
+
+    init_db()
+    try:
+        user = User.get(User.username == username)
+    except User.DoesNotExist:
+        return []
+    return [c.session_name for c in Conversation.select().where(Conversation.user == user)]


### PR DESCRIPTION
## Summary
- add session listing helper and API endpoint
- create a simple interactive CLI using Typer and httpx
- document the new CLI usage
- include httpx and typer in requirements

## Testing
- `python -m pip install -r requirements.txt`
- `python -m pip check`
- `python -m src.cli --user test` *(fails: All connection attempts failed)*

------
https://chatgpt.com/codex/tasks/task_e_6845b090d3a483219a4372ba38a553cb