### PR TITLE
Refactor API into package with module entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,10 +124,12 @@ more like a standard Ubuntu installation.
 
 ## REST API
 
-Start the API server using ``uvicorn``:
+Start the API server as a module or with ``uvicorn``:
 
 ```bash
-uvicorn src.api:app --host 0.0.0.0 --port 8000
+python -m api_app
+# or
+uvicorn api_app:app --host 0.0.0.0 --port 8000
 ```
 
 ### Endpoints

--- a/api_app/__init__.py
+++ b/api_app/__init__.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from fastapi import FastAPI, UploadFile, File, Form
-from fastapi.responses import StreamingResponse, Response
+from fastapi.responses import StreamingResponse
 from fastapi import HTTPException
 from pydantic import BaseModel
 import asyncio
@@ -9,9 +9,9 @@ import os
 import tempfile
 from pathlib import Path
 
-from .chat import ChatSession
-from .log import get_logger
-from .db import list_sessions, list_sessions_info
+from src.chat import ChatSession
+from src.log import get_logger
+from src.db import list_sessions, list_sessions_info
 
 
 _LOG = get_logger(__name__)
@@ -79,8 +79,3 @@ def create_app() -> FastAPI:
 
 
 app = create_app()
-
-if __name__ == "__main__":  # pragma: no cover - manual start
-    import uvicorn
-
-    uvicorn.run(app, host="0.0.0.0", port=int(os.getenv("PORT", "8000")))

--- a/api_app/__main__.py
+++ b/api_app/__main__.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+import os
+
+import uvicorn
+
+from . import app
+
+
+def main() -> None:
+    """Run the FastAPI application using uvicorn."""
+    uvicorn.run(app, host="0.0.0.0", port=int(os.getenv("PORT", "8000")))
+
+
+if __name__ == "__main__":  # pragma: no cover - entry point
+    main()


### PR DESCRIPTION
## Summary
- move `src/api.py` into new `api_app` package
- provide `api_app/__main__.py` entrypoint
- update README instructions for running the API

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6845b56b8dac8321ba96aaa9d2e84d18