### PR TITLE
Add placeholder response while waiting for tools

### DIFF
--- a/src/chat.py
+++ b/src/chat.py
@@ -224,6 +224,11 @@ class ChatSession:
                 exec_task = asyncio.create_task(
                     execute_terminal_async(**call.function.arguments)
                 )
+
+                placeholder = {"role": "assistant", "content": "Awaiting tool response..."}
+                messages.append(placeholder)
+                yield ChatResponse(message=Message(**placeholder))
+
                 follow_task = asyncio.create_task(self.ask(messages, think=True))
 
                 async with self._lock:
@@ -241,6 +246,7 @@ class ChatSession:
                         await follow_task
                     except asyncio.CancelledError:
                         pass
+                    messages.pop()  # remove placeholder
                     result = await exec_task
                     messages.append(
                         {


### PR DESCRIPTION
## Summary
- notify users that the assistant is waiting on a tool
- drop the placeholder message when the tool finishes early

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python run.py` *(fails: Failed to start VM: [Errno 2] No such file or directory: 'docker')*

------
https://chatgpt.com/codex/tasks/task_e_6845b6fcee688321957fa77faafda4fc