### PR TITLE
Improve LLM response handling during tool calls

### DIFF
--- a/src/vm.py
+++ b/src/vm.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import subprocess
 import asyncio
 from functools import partial
-import uuid
 from pathlib import Path
 
 from threading import Lock


### PR DESCRIPTION
## Summary
- handle pending tool calls without yielding placeholder messages
- remove placeholder tool messages when executing tools finishes
- fix linter warning by removing unused import

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6845ba98108c8321b001bc63e64f6ef2