### PR TITLE
Implement basic multi-agent framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,3 +169,12 @@ pyinstaller --onefile -n llm-chat cli_app/main.py
 ```
 
 The resulting ``llm-chat.exe`` can be used on Windows 10/11.
+
+## Multi-Agent Collaboration
+
+Each user session now spawns a team of four specialised agents: planner, researcher, developer and reviewer. Agents communicate asynchronously through the ``send_agent_message`` tool. Messages are queued so an agent's response generation is never interrupted.
+
+Tools available to the model:
+
+- ``execute_terminal`` – run shell commands inside the shared VM.
+- ``send_agent_message`` – deliver a note to another agent. The ``from`` field is filled automatically while the model may specify ``to``, ``urgency`` and optional ``cc`` fields.

--- a/src/agent_comm.py
+++ b/src/agent_comm.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import asyncio
+from typing import Dict, Tuple
+from threading import Lock
+
+
+class MessageRouter:
+    """Route messages between agents using per-agent asyncio queues."""
+
+    _queues: Dict[Tuple[str, str], asyncio.Queue[dict]] = {}
+    _lock = Lock()
+
+    @classmethod
+    def register(cls, user: str, agent: str) -> asyncio.Queue[dict]:
+        """Return the queue for ``agent`` under ``user``, creating it if needed."""
+        key = (user, agent)
+        with cls._lock:
+            queue = cls._queues.get(key)
+            if queue is None:
+                queue = asyncio.Queue()
+                cls._queues[key] = queue
+        return queue
+
+    @classmethod
+    def send(cls, user: str, agent: str, message: dict) -> None:
+        """Enqueue ``message`` for ``agent`` belonging to ``user``."""
+        queue = cls.register(user, agent)
+        queue.put_nowait(message)

--- a/src/config.py
+++ b/src/config.py
@@ -42,3 +42,19 @@ SYSTEM_PROMPT: Final[str] = (
     "absolutely unnecessary or impossible to do so. Even if you have executed a command before, "
     "always re-run it to ensure you have the most up-to-date information upon user request."
 ).strip()
+
+AGENT_PROMPTS: Final[dict[str, str]] = {
+    "planner": SYSTEM_PROMPT
+    + " You are Nova, the Planner. Break down user requests into clear tasks and"
+    + " coordinate the team. Delegate work using the send_agent_message tool and"
+    + " ensure every requirement is addressed.",
+    "researcher": SYSTEM_PROMPT
+    + " You are Orion, the Researcher. Gather facts from documents and the web."
+    + " Summarize findings concisely for the team.",
+    "developer": SYSTEM_PROMPT
+    + " You are Luna, the Developer. Implement solutions in code and verify them"
+    + " using execute_terminal. Provide scripts and technical steps when asked.",
+    "reviewer": SYSTEM_PROMPT
+    + " You are Sol, the Reviewer. Check the team's work for accuracy and clarity"
+    + " before it reaches the user. Suggest improvements if needed.",
+}

--- a/src/team.py
+++ b/src/team.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from typing import Dict
+from contextlib import AsyncExitStack
+
+from .chat import ChatSession
+from .config import AGENT_PROMPTS
+
+
+class TeamChatSession:
+    """Manage a group of cooperative agents for a single user."""
+
+    def __init__(self, user: str = "default", session: str = "default") -> None:
+        self._user = user
+        self._session = session
+        self._agents: Dict[str, ChatSession] = {
+            name: ChatSession(
+                user=user,
+                session=f"{session}-{name}",
+                agent_name=name,
+                system_prompt=prompt,
+            )
+            for name, prompt in AGENT_PROMPTS.items()
+        }
+        self._stack: AsyncExitStack | None = None
+
+    async def __aenter__(self) -> "TeamChatSession":
+        self._stack = AsyncExitStack()
+        for agent in self._agents.values():
+            await self._stack.enter_async_context(agent)
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        if self._stack:
+            await self._stack.aclose()
+            self._stack = None
+
+    async def chat_stream(self, prompt: str):
+        """Send ``prompt`` to the planner agent and stream its reply."""
+        planner = self._agents["planner"]
+        async for part in planner.chat_stream(prompt):
+            yield part
+        # Allow other agents to process queued messages in the background
+        for name, agent in self._agents.items():
+            if name == "planner":
+                continue
+            await agent._flush_incoming()


### PR DESCRIPTION
## Summary
- define per-user message router for agents
- implement agent-to-agent messaging tool
- support agent prompts in configuration
- extend ChatSession with agent features
- add simple TeamChatSession helper
- document multi-agent workflow

## Testing
- `pip install -r requirements.txt`
- `python -m compileall -q src`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6845e00595fc83219fca345445ba23d8