### PR TITLE
Improve agent team history management

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,8 @@ The resulting ``llm-chat.exe`` can be used on Windows 10/11.
 
 Each user session now spawns a team of four specialised agents: planner, researcher, developer and reviewer. Agents communicate asynchronously through the ``send_agent_message`` tool. Messages are queued so an agent's response generation is never interrupted.
 
+Use ``TeamChatSession`` to coordinate the group. Each agent keeps a separate conversation history which can be retrieved at any time with ``team.get_history(agent_name)``.
+
 Tools available to the model:
 
 - ``execute_terminal`` – run shell commands inside the shared VM.

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,10 +1,12 @@
 from .chat import ChatSession
+from .team import TeamChatSession
 from .tools import execute_terminal, execute_terminal_async, set_vm
 from .utils import limit_chars
 from .vm import LinuxVM
 
 __all__ = [
     "ChatSession",
+    "TeamChatSession",
     "execute_terminal",
     "execute_terminal_async",
     "set_vm",

--- a/src/history.py
+++ b/src/history.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from typing import List
+import json
+
+from ollama import Message
+
+from .db import Conversation, Message as DBMessage
+from .schema import Msg
+
+
+def load_history(conversation: Conversation) -> List[Msg]:
+    """Return chat history for ``conversation``.
+
+    System messages are skipped. Assistant messages are parsed for tool
+    calls, falling back to plain text when JSON decoding fails.
+    """
+    messages: List[Msg] = []
+    for msg in conversation.messages.order_by(DBMessage.created_at):
+        if msg.role == "system":
+            continue
+        if msg.role == "assistant":
+            try:
+                calls = json.loads(msg.content)
+            except json.JSONDecodeError:
+                messages.append({"role": "assistant", "content": msg.content})
+            else:
+                messages.append(
+                    {
+                        "role": "assistant",
+                        "tool_calls": [Message.ToolCall(**c) for c in calls],
+                    }
+                )
+        elif msg.role == "user":
+            messages.append({"role": "user", "content": msg.content})
+        else:
+            messages.append({"role": "tool", "content": msg.content})
+    return messages

--- a/src/team.py
+++ b/src/team.py
@@ -5,6 +5,8 @@ from contextlib import AsyncExitStack
 
 from .chat import ChatSession
 from .config import AGENT_PROMPTS
+from .history import load_history
+from .schema import Msg
 
 
 class TeamChatSession:
@@ -34,6 +36,14 @@ class TeamChatSession:
         if self._stack:
             await self._stack.aclose()
             self._stack = None
+
+    def get_history(self, agent: str) -> list[Msg]:
+        """Return the chat history for ``agent`` from the database."""
+
+        session = self._agents.get(agent)
+        if not session:
+            raise KeyError(agent)
+        return load_history(session._conversation)
 
     async def chat_stream(self, prompt: str):
         """Send ``prompt`` to the planner agent and stream its reply."""


### PR DESCRIPTION
## Summary
- expose TeamChatSession in package exports
- add dedicated helper to load conversation history from database
- return in-memory history from ChatSession
- allow retrieving per-agent history in TeamChatSession
- document per-agent history retrieval in README

## Testing
- `python -m pip install -r requirements.txt`
- `python -m pip check`
- `python -m src.cli --help | head`

------
https://chatgpt.com/codex/tasks/task_e_6845e457cccc832194b6df614297e46a