### PR TITLE
Fix async task creation when forwarding to junior agent

### DIFF
--- a/src/team.py
+++ b/src/team.py
@@ -23,15 +23,19 @@ def set_team(team: "TeamChatSession" | None) -> None:
     _TEAM = team
 
 
-def send_to_junior(message: str) -> str:
+async def send_to_junior(message: str) -> str:
+    """Forward ``message`` to the junior agent and return a status string."""
+
     if _TEAM is None:
         return "No active team"
+
     _TEAM.queue_message_to_junior(message)
     return "Message sent to junior"
 
 
-async def send_to_junior_async(message: str) -> str:
-    return send_to_junior(message)
+# Backwards compatibility ---------------------------------------------------
+
+send_to_junior_async = send_to_junior
 
 
 class TeamChatSession:


### PR DESCRIPTION
## Summary
- fix `send_to_junior` so it's async and can be scheduled on the running loop
- keep `send_to_junior_async` as a backwards compatible alias

## Testing
- `pip install -r requirements.txt`
- `python run.py` *(fails: FileNotFoundError: [Errno 2] No such file or directory: 'docker')*

------
https://chatgpt.com/codex/tasks/task_e_6845f5ab84fc8321a7c486809df614b9