### PR TITLE
Ensure VM command output is captured

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ## Features
 
 - **Persistent chat history** – conversations are stored in `chat.db` per user and session so they can be resumed later.
-- **Tool execution** – a built-in `execute_terminal` tool runs commands inside a Docker-based VM. Network access is enabled and both stdout and stderr are captured (up to 10,000 characters). The VM is reused across chats when `PERSIST_VMS=1` so installed packages remain available.
+- **Tool execution** – a built-in `execute_terminal` tool runs commands inside a Docker-based VM using `docker exec -i`. Network access is enabled and both stdout and stderr are captured (up to 10,000 characters). The VM is reused across chats when `PERSIST_VMS=1` so installed packages remain available.
 - **System prompts** – every request includes a system prompt that guides the assistant to plan tool usage, verify results and avoid unnecessary jargon.
 
 ## Environment Variables

--- a/src/vm.py
+++ b/src/vm.py
@@ -120,6 +120,7 @@ class LinuxVM:
         cmd = [
             "docker",
             "exec",
+            "-i",
         ]
         if detach:
             cmd.append("-d")


### PR DESCRIPTION
## Summary
- ensure the Docker VM keeps stdin open with `docker exec -i`
- document the improved command execution in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684795c8393083218a38e45e5f90b380