### PR TITLE
Improve frontend style with glassmorphism

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -8,8 +8,8 @@
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
+  --font-sans: ui-sans-serif, system-ui, sans-serif;
+  --font-mono: ui-monospace, monospace;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -23,4 +23,13 @@ body {
   background: var(--background);
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; transform: translateY(5px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+
+.animate-fadeIn {
+  animation: fadeIn 0.3s ease-in-out;
 }

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,16 +1,5 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
-
-const geistSans = Geist({
-  variable: "--font-geist-sans",
-  subsets: ["latin"],
-});
-
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
-});
 
 export const metadata: Metadata = {
   title: "Create Next App",
@@ -24,9 +13,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-      >
+      <body className="antialiased">
         {children}
       </body>
     </html>

--- a/frontend/src/components/MessageInput.tsx
+++ b/frontend/src/components/MessageInput.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import GlassButton from './ui/GlassButton';
+
+interface MessageInputProps {
+  value: string;
+  onChange: (value: string) => void;
+  onSend: () => void;
+  disabled?: boolean;
+}
+
+export default function MessageInput({ value, onChange, onSend, disabled }: MessageInputProps) {
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    onSend();
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="flex gap-2 p-2">
+      <input
+        type="text"
+        className="flex-1 bg-white/20 backdrop-blur-md border border-white/30 text-white px-3 py-2 rounded-md focus:outline-none"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder="Type your message..."
+      />
+      <GlassButton type="submit" disabled={disabled}>
+        Send
+      </GlassButton>
+    </form>
+  );
+}

--- a/frontend/src/components/MessageItem.tsx
+++ b/frontend/src/components/MessageItem.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+export interface Message {
+  role: 'user' | 'assistant';
+  content: string;
+}
+
+interface MessageItemProps {
+  message: Message;
+}
+
+export default function MessageItem({ message }: MessageItemProps) {
+  const alignment = message.role === 'user' ? 'items-end' : 'items-start';
+  return (
+    <div className={`flex flex-col ${alignment} animate-fadeIn`}>      
+      <div className="w-full max-w-xl p-3 my-2 bg-white/10 border border-white/30 backdrop-blur-lg rounded-lg shadow-md">
+        <p className="whitespace-pre-wrap">{message.content}</p>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/MessageList.tsx
+++ b/frontend/src/components/MessageList.tsx
@@ -1,0 +1,20 @@
+import React, { forwardRef } from 'react';
+import MessageItem, { Message } from './MessageItem';
+
+interface MessageListProps {
+  messages: Message[];
+}
+
+const MessageList = forwardRef<HTMLDivElement, MessageListProps>(({ messages }, ref) => {
+  return (
+    <div className="flex-1 overflow-y-auto p-2" ref={ref}>
+      {messages.map((msg, idx) => (
+        <MessageItem key={idx} message={msg} />
+      ))}
+    </div>
+  );
+});
+
+MessageList.displayName = 'MessageList';
+
+export default MessageList;

--- a/frontend/src/components/ui/GlassButton.tsx
+++ b/frontend/src/components/ui/GlassButton.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+interface GlassButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  children: React.ReactNode;
+}
+
+export default function GlassButton({ children, className = '', ...props }: GlassButtonProps) {
+  return (
+    <button
+      className={`bg-white/20 backdrop-blur-md border border-white/30 text-white px-4 py-2 rounded-md shadow-lg transition-all hover:bg-white/30 active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed ${className}`}
+      {...props}
+    >
+      {children}
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary
- redesign chat UI using glassmorphism
- implement stack style chat with animations
- add reusable glass button component
- tweak global CSS for fade animations
- remove Google font dependencies to avoid build failure

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684849cf138083218b19329730f25d02