### PR TITLE
Improve chat UI styling and typography

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -49,7 +49,7 @@
 body {
   background: var(--background);
   color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: var(--font-sans, Arial, Helvetica, sans-serif);
 }
 
 @keyframes fadeIn {

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,5 +1,8 @@
 import type { Metadata } from "next";
+import { Inter } from "next/font/google";
 import "./globals.css";
+
+const inter = Inter({ subsets: ["latin"], variable: "--font-sans", display: "swap" });
 
 export const metadata: Metadata = {
   title: "Create Next App",
@@ -12,10 +15,8 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
-      <body className="antialiased">
-        {children}
-      </body>
+    <html lang="en" className={inter.variable}>
+      <body className="antialiased">{children}</body>
     </html>
   );
 }

--- a/frontend/src/components/ChatApp.tsx
+++ b/frontend/src/components/ChatApp.tsx
@@ -51,8 +51,8 @@ export default function ChatApp() {
   };
 
   return (
-    <div className="flex flex-col items-center h-screen bg-gradient-to-br from-white to-gray-100 text-gray-900 p-4">
-      <div className="w-full max-w-3xl flex flex-col flex-1 glass-panel rounded-lg overflow-hidden">
+    <div className="flex flex-col min-h-screen bg-gradient-to-br from-white to-gray-100 text-gray-900 p-4">
+      <div className="w-full max-w-3xl flex flex-col flex-1 mx-auto glass-panel rounded-lg overflow-hidden">
         <MessageList ref={listRef} messages={messages} />
         <MessageInput value={input} onChange={setInput} onSend={sendMessage} disabled={loading} />
       </div>

--- a/frontend/src/components/MessageInput.tsx
+++ b/frontend/src/components/MessageInput.tsx
@@ -15,7 +15,7 @@ export default function MessageInput({ value, onChange, onSend, disabled }: Mess
   };
 
   return (
-    <form onSubmit={handleSubmit} className="flex gap-2 p-2">
+    <form onSubmit={handleSubmit} className="flex gap-2 p-2 border-t border-gray-200">
       <input
         type="text"
         className="flex-1 bg-white/60 backdrop-blur-sm border border-gray-300 text-gray-900 px-3 py-2 rounded-md focus:outline-none"

--- a/frontend/src/components/MessageItem.tsx
+++ b/frontend/src/components/MessageItem.tsx
@@ -14,7 +14,7 @@ export default function MessageItem({ message }: MessageItemProps) {
   return (
     <div className={`flex flex-col ${alignment} animate-fadeIn`}>
       <div className="w-full max-w-xl p-3 my-2 glass-panel rounded-lg shadow-md">
-        <p className="whitespace-pre-wrap">{message.content}</p>
+        <p className="whitespace-pre-wrap break-words">{message.content}</p>
       </div>
     </div>
   );

--- a/frontend/src/components/MessageList.tsx
+++ b/frontend/src/components/MessageList.tsx
@@ -7,7 +7,7 @@ interface MessageListProps {
 
 const MessageList = forwardRef<HTMLDivElement, MessageListProps>(({ messages }, ref) => {
   return (
-    <div className="flex-1 overflow-y-auto p-2" ref={ref}>
+    <div className="flex-1 overflow-y-auto p-4 space-y-4" ref={ref}>
       {messages.map((msg, idx) => (
         <MessageItem key={idx} message={msg} />
       ))}


### PR DESCRIPTION
## Summary
- load the Inter font globally with next/font
- use the font in global styles
- center and align the main chat container
- add spacing in the message list
- handle long words in chat messages
- add a divider line above the input field

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68484c575db48321975de578240969d4