### PR TITLE
Add global background image

### DIFF
--- a/frontend/public/background.svg
+++ b/frontend/public/background.svg
@@ -1,0 +1,9 @@
+<svg width="100%" height="100%" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#a1c4fd;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#c2e9fb;stop-opacity:1" />
+    </linearGradient>
+  </defs>
+  <rect width="100%" height="100%" fill="url(#grad)" />
+</svg>

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -47,7 +47,8 @@
 }
 
 body {
-  background: var(--background);
+  background: var(--background) url('/background.svg') no-repeat center center fixed;
+  background-size: cover;
   color: var(--foreground);
   font-family: var(--font-sans, Arial, Helvetica, sans-serif);
 }


### PR DESCRIPTION
## Summary
- add an SVG background gradient
- reference background image from global stylesheet

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68484e2f31688321b89b0e12b51b55db