### PR TITLE
Enable full VM browsing in Gradio

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 - **Persistent chat history** – conversations are stored in `chat.db` per user and session so they can be resumed later.
 - **Tool execution** – a built-in `execute_terminal` tool runs commands inside a Docker-based VM using `docker exec -i`. Network access is enabled and both stdout and stderr are captured (up to 10,000 characters). The VM is reused across chats when `PERSIST_VMS=1` so installed packages remain available.
 - **System prompts** – every request includes a system prompt that guides the assistant to plan tool usage, verify results and avoid unnecessary jargon.
+- **Gradio interface** – a web UI in `gradio_app.py` lets you chat and browse the VM file system. The Files tab now allows navigating any directory inside the container.
 
 ## Environment Variables
 


### PR DESCRIPTION
## Summary
- expose VM filesystem in the Gradio interface
- update Files tab to accept session and start from `/`
- document new capability in README

## Testing
- `python -m py_compile gradio_app.py src/*.py api/*.py run.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6848da4fef1c8321a82b3b21aa79606a