### PR TITLE
Fix file listing display in Gradio UI

### DIFF
--- a/gradio_app.py
+++ b/gradio_app.py
@@ -68,14 +68,14 @@ async def list_dir(path: str, session: str, token: OAuthToken):
     output = await _vm_execute(user, session, cmd)
     if output.startswith("ls:"):
         return []
-    entries = []
+    entries: list[list[str | bool]] = []
     for line in output.splitlines():
         line = line.strip()
         if not line or line in (".", ".."):
             continue
         is_dir = line.endswith("/")
         name = line[:-1] if is_dir else line
-        entries.append({"name": name, "is_dir": is_dir})
+        entries.append([name, is_dir])
     return entries
 
 


### PR DESCRIPTION
## Summary
- fix `list_dir` return type so Gradio `Dataframe` shows file names

## Testing
- `python -m py_compile gradio_app.py`

------
https://chatgpt.com/codex/tasks/task_e_6848dc3a069c8321baeb44c1f96baa55