### PR TITLE
Add configurable think option

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The script issues a sample command to the model and prints the streamed response
 ### Uploading Documents
 
 ```python
-async with ChatSession() as chat:
+async with ChatSession(think=False) as chat:
     path = chat.upload_document("path/to/file.pdf")
     async for part in chat.chat_stream(f"Summarize {path}"):
         print(part)

--- a/src/team.py
+++ b/src/team.py
@@ -44,6 +44,8 @@ class TeamChatSession:
         session: str = "default",
         host: str = OLLAMA_HOST,
         model: str = MODEL_NAME,
+        *,
+        think: bool = True,
     ) -> None:
         self._to_junior: asyncio.Queue[tuple[str, asyncio.Future[str], bool]] = asyncio.Queue()
         self._to_senior: asyncio.Queue[str] = asyncio.Queue()
@@ -55,6 +57,7 @@ class TeamChatSession:
             model=model,
             system_prompt=SYSTEM_PROMPT,
             tools=[execute_terminal, send_to_junior],
+            think=think,
         )
         self.junior = ChatSession(
             user=user,
@@ -63,6 +66,7 @@ class TeamChatSession:
             model=model,
             system_prompt=JUNIOR_PROMPT,
             tools=[execute_terminal],
+            think=think,
         )
 
     async def __aenter__(self) -> "TeamChatSession":


### PR DESCRIPTION
## Summary
- make think controllable when creating ChatSession or TeamChatSession
- expose the current think setting via a property
- allow README example to show setting think

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m compileall -q src app.py bot api run.py`

------
https://chatgpt.com/codex/tasks/task_e_684ac7eea6688321a095d45527424dd0