### PR TITLE
Ensure tool placeholders persist when LLM responds first

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -18,6 +18,9 @@ VM_STATE_DIR: Final[str] = os.getenv(
 )
 DB_PATH: Final[str] = os.getenv("DB_PATH", str(Path.cwd() / "chat.db"))
 
+# Content used when waiting for tool execution.
+TOOL_PLACEHOLDER_CONTENT: Final[str] = "Awaiting tool response..."
+
 SYSTEM_PROMPT: Final[str] = (
     "You are Starlette, the senior agent leading a two-agent team. "
     "A junior agent named Starlette Jr. assists you but never speaks to the user. "


### PR DESCRIPTION
## Summary
- add `TOOL_PLACEHOLDER_CONTENT` constant
- centralise saving of placeholder messages via `_save_tool_placeholder`
- use the constant across `ChatSession`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ad268bf4c8321a19639cd9ff39a9d