### PR TITLE
Refactor chat module into package

### DIFF
--- a/src/chat/__init__.py
+++ b/src/chat/__init__.py
@@ -1,0 +1,4 @@
+from .session import ChatSession
+
+__all__ = ["ChatSession"]
+

--- a/src/chat/messages.py
+++ b/src/chat/messages.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import json
+from typing import List
+
+from ollama import Message
+
+from ..schema import Msg
+from ..db import Conversation, Message as DBMessage
+
+__all__ = [
+    "serialize_tool_calls",
+    "format_output",
+    "remove_tool_placeholder",
+    "store_assistant_message",
+]
+
+
+def serialize_tool_calls(calls: List[Message.ToolCall]) -> str:
+    """Return tool calls as a JSON string."""
+
+    return json.dumps([c.model_dump() for c in calls])
+
+
+def format_output(message: Message) -> str:
+    """Return message content if present."""
+
+    return message.content or ""
+
+
+def remove_tool_placeholder(messages: List[Msg], placeholder: str) -> None:
+    """Remove the pending placeholder message if present."""
+
+    for i in range(len(messages) - 1, -1, -1):
+        msg = messages[i]
+        if msg.get("role") == "tool" and msg.get("content") == placeholder:
+            messages.pop(i)
+            break
+
+
+def store_assistant_message(conversation: Conversation, message: Message) -> None:
+    """Persist assistant messages, storing tool calls when present."""
+
+    data = {"content": message.content or ""}
+    if message.tool_calls:
+        data["tool_calls"] = [c.model_dump() for c in message.tool_calls]
+
+    DBMessage.create(
+        conversation=conversation,
+        role="assistant",
+        content=json.dumps(data),
+    )
+

--- a/src/chat/state.py
+++ b/src/chat/state.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+
+
+@dataclass
+class SessionState:
+    """Container for per-conversation state."""
+
+    lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+    status: str = "idle"
+    tool_task: asyncio.Task | None = None
+    placeholder_saved: bool = False
+
+
+_session_states: dict[int, SessionState] = {}
+
+
+def get_state(conv_id: int) -> SessionState:
+    """Return existing state for ``conv_id`` or create a new one."""
+
+    state = _session_states.get(conv_id)
+    if state is None:
+        state = SessionState()
+        _session_states[conv_id] = state
+    return state
+


### PR DESCRIPTION
## Summary
- move `chat.py` into `src/chat` package
- split session state and message utilities into separate modules
- keep `ChatSession` public API unchanged but more modular

## Testing
- `python -m py_compile $(find . -name '*.py' -print)`
- `python run.py` *(fails: ModuleNotFoundError: No module named 'ollama')*

------
https://chatgpt.com/codex/tasks/task_e_684ad6fcbc388321b89b890198b504d4