### PR TITLE
feat: yield message content before tool execution

### DIFF
--- a/agent/chat/session.py
+++ b/agent/chat/session.py
@@ -209,9 +209,12 @@ class ChatSession:
         conversation: Conversation,
         depth: int = 0,
     ) -> AsyncIterator[ChatResponse]:
+        if response.message.content:
+            # Yield the assistant's content even when a tool call is present.
+            # This ensures helpful context isn't dropped before executing tools.
+            yield response
+
         if not response.message.tool_calls:
-            if response.message.content:
-                yield response
             async with self._lock:
                 self._state = "idle"
             return


### PR DESCRIPTION
## Summary
- emit assistant text even when a tool call is triggered

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684b76557cc48321bd54e6ba8dc88c70