### PR TITLE
Add simple chat helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,20 @@ python run.py
 
 The script issues a sample command to the model and prints the streamed response. Uploaded files go to `uploads` and are mounted in the VM at `/data`.
 
+### Simple API
+
+Convenience helpers allow chatting without managing sessions directly:
+
+```python
+import asyncio
+import agent
+
+response = asyncio.run(agent.solo_chat("Hello"))
+print(response)
+```
+
+Use `agent.team_chat` the same way to utilise the senior and junior agents.
+
 ### Uploading Documents
 
 ```python

--- a/agent/__init__.py
+++ b/agent/__init__.py
@@ -6,6 +6,12 @@ from .sessions.team import (
     set_team,
 )
 from .sessions.solo import SoloChatSession
+from .simple import (
+    solo_chat,
+    solo_chat_stream,
+    team_chat,
+    team_chat_stream,
+)
 from .tools import execute_terminal, execute_terminal_async, set_vm
 from .utils.helpers import limit_chars
 from .vm import LinuxVM
@@ -22,5 +28,9 @@ __all__ = [
     "set_vm",
     "LinuxVM",
     "limit_chars",
+    "solo_chat",
+    "team_chat",
+    "solo_chat_stream",
+    "team_chat_stream",
 ]
 

--- a/agent/simple.py
+++ b/agent/simple.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import asyncio
+from typing import AsyncIterator
+
+from .sessions.solo import SoloChatSession
+from .sessions.team import TeamChatSession
+
+__all__ = [
+    "solo_chat",
+    "team_chat",
+    "solo_chat_stream",
+    "team_chat_stream",
+]
+
+
+async def solo_chat_stream(
+    prompt: str,
+    *,
+    user: str = "default",
+    session: str = "default",
+    think: bool = True,
+) -> AsyncIterator[str]:
+    """Stream the assistant's response using :class:`SoloChatSession`."""
+
+    async with SoloChatSession(user=user, session=session, think=think) as chat:
+        async for part in chat.chat_stream(prompt):
+            yield part
+
+
+async def team_chat_stream(
+    prompt: str,
+    *,
+    user: str = "default",
+    session: str = "default",
+    think: bool = True,
+) -> AsyncIterator[str]:
+    """Stream the assistant's response using :class:`TeamChatSession`."""
+
+    async with TeamChatSession(user=user, session=session, think=think) as chat:
+        async for part in chat.chat_stream(prompt):
+            yield part
+
+
+async def solo_chat(
+    prompt: str,
+    *,
+    user: str = "default",
+    session: str = "default",
+    think: bool = True,
+) -> str:
+    """Return the full response from a :class:`SoloChatSession`."""
+
+    parts: list[str] = []
+    async for part in solo_chat_stream(
+        prompt, user=user, session=session, think=think
+    ):
+        if part:
+            parts.append(part)
+    return "\n".join(parts)
+
+
+async def team_chat(
+    prompt: str,
+    *,
+    user: str = "default",
+    session: str = "default",
+    think: bool = True,
+) -> str:
+    """Return the full response from a :class:`TeamChatSession`."""
+
+    parts: list[str] = []
+    async for part in team_chat_stream(
+        prompt, user=user, session=session, think=think
+    ):
+        if part:
+            parts.append(part)
+    return "\n".join(parts)


### PR DESCRIPTION
## Summary
- expose new `solo_chat` and `team_chat` helpers
- re-export convenience functions from `agent.__init__`
- document easy usage in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684b76dacd408321aca75f9e53e35a29