### PR TITLE
Add manual VM command execution via Discord

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,12 @@ asyncio.run(agent.delete_path("/data/new.txt"))
 
 Attachments sent to the bot are uploaded automatically and the VM path is returned so they can be referenced in later messages.
 
+Run shell commands manually with `!exec <command>`. For example:
+
+```text
+!exec ls /data
+```
+
 ## VM Configuration
 
 The shell commands run inside a Docker container. By default the image defined by `VM_IMAGE` is used (falling back to `python:3.11-slim`). When `PERSIST_VMS=1` (default) each user keeps the same container across sessions. Set `VM_STATE_DIR` to choose where per-user data is stored on the host.

--- a/bot/discord_bot.py
+++ b/bot/discord_bot.py
@@ -72,6 +72,18 @@ class DiscordTeamBot(commands.Bot):
                 f"Chat history cleared ({deleted} messages deleted).",
             )
 
+        @self.command(name="exec")
+        async def exec_cmd(ctx: commands.Context, *, command: str) -> None:
+            """Run ``command`` inside the user's VM and return the output."""
+
+            output = await agent.vm_execute(command, user=str(ctx.author.id))
+            output = output.strip()
+            if not output:
+                output = "(no output)"
+            if len(output) > 1900:
+                output = output[:1900] + "..."
+            await ctx.reply(f"```\n{output}\n```", mention_author=False)
+
     # ------------------------------------------------------------------
     # Helpers
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- allow Discord users to run shell commands in their VM with `!exec`
- document the `!exec` command in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b7dd6d19c8321b6d167b909a71438