### PR TITLE
Add configurable session settings & packaging

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,1 @@
+from .agent import *

--- a/agent/__init__.py
+++ b/agent/__init__.py
@@ -22,6 +22,7 @@ from .utils.helpers import limit_chars
 from .utils.speech import transcribe_audio
 from .vm import LinuxVM
 from .utils.memory import get_memory, set_memory, edit_memory, edit_protected_memory
+from .config import Config, DEFAULT_CONFIG
 
 __all__ = [
     "ChatSession",
@@ -48,5 +49,7 @@ __all__ = [
     "set_memory",
     "edit_memory",
     "edit_protected_memory",
+    "Config",
+    "DEFAULT_CONFIG",
 ]
 

--- a/agent/config/__init__.py
+++ b/agent/config/__init__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 from pathlib import Path
 from typing import Final
+from dataclasses import dataclass
 from dotenv import load_dotenv
 load_dotenv()
 
@@ -107,3 +108,58 @@ DEFAULT_MEMORY_TEMPLATE: Final[str] = (
     "  \"protected_memory\": {}\n"
     "}"
 )
+
+
+@dataclass(slots=True)
+class Config:
+    """Container for all configuration options."""
+
+    model_name: str = MODEL_NAME
+    ollama_host: str = OLLAMA_HOST
+    max_tool_call_depth: int = MAX_TOOL_CALL_DEPTH
+    num_ctx: int = NUM_CTX
+    upload_dir: str = UPLOAD_DIR
+    vm_image: str = VM_IMAGE
+    persist_vms: bool = PERSIST_VMS
+    vm_state_dir: str = VM_STATE_DIR
+    vm_docker_host: str | None = VM_DOCKER_HOST
+    db_path: str = DB_PATH
+    hard_timeout: int = HARD_TIMEOUT
+    log_level: str = LOG_LEVEL
+    tool_placeholder_content: str = TOOL_PLACEHOLDER_CONTENT
+    system_prompt: str = SYSTEM_PROMPT
+    solo_system_prompt: str = SOLO_SYSTEM_PROMPT
+    junior_prompt: str = JUNIOR_PROMPT
+    mini_agent_prompt: str = MINI_AGENT_PROMPT
+    memory_limit: int = MEMORY_LIMIT
+    max_mini_agents: int = MAX_MINI_AGENTS
+    default_memory_template: str = DEFAULT_MEMORY_TEMPLATE
+
+
+DEFAULT_CONFIG = Config()
+
+
+__all__ = [
+    "Config",
+    "DEFAULT_CONFIG",
+    "MODEL_NAME",
+    "OLLAMA_HOST",
+    "MAX_TOOL_CALL_DEPTH",
+    "NUM_CTX",
+    "UPLOAD_DIR",
+    "VM_IMAGE",
+    "PERSIST_VMS",
+    "VM_STATE_DIR",
+    "VM_DOCKER_HOST",
+    "DB_PATH",
+    "HARD_TIMEOUT",
+    "LOG_LEVEL",
+    "TOOL_PLACEHOLDER_CONTENT",
+    "SYSTEM_PROMPT",
+    "SOLO_SYSTEM_PROMPT",
+    "JUNIOR_PROMPT",
+    "MINI_AGENT_PROMPT",
+    "MEMORY_LIMIT",
+    "MAX_MINI_AGENTS",
+    "DEFAULT_MEMORY_TEMPLATE",
+]

--- a/agent/db/__init__.py
+++ b/agent/db/__init__.py
@@ -20,6 +20,20 @@ _DB_PATH = Path(DB_PATH)
 _db = SqliteDatabase(_DB_PATH)
 
 
+def configure_db(path: str) -> None:
+    """Update the database location used by the manager."""
+
+    global _db, _DB_PATH, db
+    new_path = Path(path)
+    if new_path == _DB_PATH:
+        return
+    if not _db.is_closed():
+        _db.close()
+    _DB_PATH = new_path
+    _db = SqliteDatabase(_DB_PATH)
+    db = DatabaseManager(_db)
+
+
 class BaseModel(Model):
     class Meta:
         database = _db
@@ -168,6 +182,7 @@ __all__ = [
     "Message",
     "Document",
     "db",
+    "configure_db",
     "reset_history",
     "list_sessions",
     "list_sessions_info",

--- a/agent/sessions/solo.py
+++ b/agent/sessions/solo.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from ..chat import ChatSession
-from ..config import OLLAMA_HOST, MODEL_NAME, SOLO_SYSTEM_PROMPT
+from ..config import Config, DEFAULT_CONFIG
 from ..tools import execute_terminal
 
 __all__ = ["SoloChatSession"]
@@ -14,19 +14,22 @@ class SoloChatSession(ChatSession):
         self,
         user: str = "default",
         session: str = "default",
-        host: str = OLLAMA_HOST,
-        model: str = MODEL_NAME,
+        host: str | None = None,
+        model: str | None = None,
         *,
         think: bool = True,
+        config: Config | None = None,
     ) -> None:
+        config = config or DEFAULT_CONFIG
         super().__init__(
             user=user,
             session=session,
-            host=host,
-            model=model,
-            system_prompt=SOLO_SYSTEM_PROMPT,
+            host=host or config.ollama_host,
+            model=model or config.model_name,
+            system_prompt=config.solo_system_prompt,
             tools=[execute_terminal],
             think=think,
+            config=config,
         )
 
 from ..utils.debug import debug_all

--- a/agent/simple.py
+++ b/agent/simple.py
@@ -7,6 +7,7 @@ import shlex
 
 from .sessions.solo import SoloChatSession
 from .sessions.team import TeamChatSession
+from .config import Config
 from .vm import VMRegistry
 
 __all__ = [
@@ -27,9 +28,15 @@ async def solo_chat(
     user: str = "default",
     session: str = "default",
     think: bool = True,
+    config: Config | None = None,
     extra: dict[str, str] | None = None,
 ) -> AsyncIterator[str]:
-    async with SoloChatSession(user=user, session=session, think=think) as chat:
+    async with SoloChatSession(
+        user=user,
+        session=session,
+        think=think,
+        config=config,
+    ) as chat:
         async for part in chat.chat_stream(prompt, extra=extra):
             yield part
 
@@ -40,9 +47,15 @@ async def team_chat(
     user: str = "default",
     session: str = "default",
     think: bool = True,
+    config: Config | None = None,
     extra: dict[str, str] | None = None,
 ) -> AsyncIterator[str]:
-    async with TeamChatSession(user=user, session=session, think=think) as chat:
+    async with TeamChatSession(
+        user=user,
+        session=session,
+        think=think,
+        config=config,
+    ) as chat:
         async for part in chat.chat_stream(prompt, extra=extra):
             yield part
 
@@ -52,12 +65,18 @@ async def upload_document(
     *,
     user: str = "default",
     session: str = "default",
+    config: Config | None = None,
 ) -> str:
     """Upload ``file_path`` for access inside the VM.
 
     The file becomes available under ``/data`` in the VM.
     """
-    async with SoloChatSession(user=user, session=session, think=False) as chat:
+    async with SoloChatSession(
+        user=user,
+        session=session,
+        think=False,
+        config=config,
+    ) as chat:
         return chat.upload_document(file_path)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,22 @@
+[project]
+name = "llmos-agent"
+version = "0.1.0"
+description = "Asynchronous chat agent with Ollama integration"
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = [
+    "ollama",
+    "peewee",
+    "discord.py",
+    "colorama",
+    "python-dotenv",
+    "openai-whisper",
+]
+
+[build-system]
+requires = ["setuptools>=61"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["agent*", "bot*"]


### PR DESCRIPTION
## Summary
- introduce `Config` dataclass for all settings
- allow chat sessions to override config values
- propagate configuration to VM, DB and sessions
- expose config via package init and add packaging metadata

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685106ddeeec832194e920d06e889931