### PR TITLE
Refactor server into package

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ The server exposes endpoints for chatting, file management and memory operations
 Launch a persistent WebSocket service to stream responses and VM notifications:
 
 ```bash
-python run_ws.py --host 0.0.0.0 --port 8765
+python -m agent.server --host 0.0.0.0 --port 8765
 ```
 
 Clients should connect via the WebSocket protocol and can specify the user and

--- a/agent/server/__init__.py
+++ b/agent/server/__init__.py
@@ -1,0 +1,5 @@
+"""WebSocket server package."""
+
+from .websocket import AgentWebSocketServer
+
+__all__ = ["AgentWebSocketServer"]

--- a/agent/server/__main__.py
+++ b/agent/server/__main__.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import asyncio
+import argparse
+
+from . import AgentWebSocketServer
+from ..vm import VMRegistry
+
+
+async def _main(host: str, port: int) -> None:
+    server = AgentWebSocketServer(host=host, port=port)
+    await server.start()
+    try:
+        await asyncio.Future()  # run forever
+    finally:
+        await server.stop()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run websocket server")
+    parser.add_argument("--host", default="0.0.0.0", help="Bind address")
+    parser.add_argument("--port", type=int, default=8765, help="Listen port")
+    args = parser.parse_args()
+
+    asyncio.run(_main(args.host, args.port))
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        VMRegistry.shutdown_all()

--- a/agent/server/websocket.py
+++ b/agent/server/websocket.py
@@ -7,9 +7,9 @@ from urllib.parse import parse_qs, urlparse
 from websockets.exceptions import ConnectionClosed
 from websockets.server import WebSocketServer, WebSocketServerProtocol, serve
 
-from .sessions.team import TeamChatSession
-from .config import Config, DEFAULT_CONFIG
-from .utils.logging import get_logger
+from ..sessions.team import TeamChatSession
+from ..config import Config, DEFAULT_CONFIG
+from ..utils.logging import get_logger
 
 
 class StreamingTeamChatSession(TeamChatSession):

--- a/run_ws.py
+++ b/run_ws.py
@@ -1,35 +1,4 @@
-from __future__ import annotations
-
-import asyncio
-import argparse
-
-from agent.server import AgentWebSocketServer
-from agent.vm import VMRegistry
-
-
-async def _main(host: str, port: int) -> None:
-    server = AgentWebSocketServer(host=host, port=port)
-    await server.start()
-    try:
-        await asyncio.Future()  # run forever
-    finally:
-        await server.stop()
-
-
-def main() -> None:
-    parser = argparse.ArgumentParser(description="Run websocket server")
-    parser.add_argument("--host", default="0.0.0.0", help="Bind address")
-    parser.add_argument("--port", type=int, default=8765, help="Listen port")
-    args = parser.parse_args()
-
-    asyncio.run(_main(args.host, args.port))
-
+from agent.server.__main__ import main
 
 if __name__ == "__main__":
-    try:
-        main()
-    except KeyboardInterrupt:
-        pass
-    finally:
-        VMRegistry.shutdown_all()
-
+    main()


### PR DESCRIPTION
## Summary
- move WebSocket server implementation into new `agent.server` package
- provide `__init__` and `__main__` entrypoints
- update root `run_ws.py` to use the package entrypoint
- update README instructions for running the WebSocket server

## Testing
- `python -m agent.server --help` *(fails: ModuleNotFoundError: No module named 'ollama')*

------
https://chatgpt.com/codex/tasks/task_e_68545111d2c08321ba9e30e05e441bdf