### PR TITLE
Extend websocket server with API endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,17 @@ asyncio.run(chat())
 ```
 
 
+JSON payloads may also be sent to access other API functions. Each message must
+include a ``command`` field and optional ``args`` mapping:
+
+```json
+{"command": "list_dir", "args": {"path": "/data"}}
+```
+
+Responses for non-streaming commands are JSON encoded. Streaming commands such
+as ``solo_chat`` send text fragments incrementally.
+
+
 
 ## API Overview
 

--- a/agent/server/endpoints.py
+++ b/agent/server/endpoints.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+"""Command dispatchers for :mod:`agent.server`.
+
+This module exposes a single :func:`dispatch_command` coroutine used by the
+:class:`~agent.server.websocket.AgentWebSocketServer` to execute API functions
+based on JSON requests received from clients.
+"""
+
+from typing import Any, AsyncIterator, Iterable
+import json
+
+from ..simple import (
+    solo_chat,
+    team_chat,
+    upload_document,
+    list_dir,
+    read_file,
+    write_file,
+    delete_path,
+    vm_execute,
+    send_notification,
+)
+from ..config import Config
+from ..sessions.team import TeamChatSession
+
+
+async def _yield_stream(stream: AsyncIterator[str]) -> AsyncIterator[str]:
+    """Yield all elements from ``stream``."""
+
+    async for part in stream:
+        if part is None:
+            continue
+        yield part
+
+
+async def dispatch_command(
+    command: str,
+    params: dict[str, Any] | None,
+    *,
+    user: str,
+    session: str,
+    think: bool,
+    config: Config,
+    chat: TeamChatSession | None = None,
+) -> AsyncIterator[str]:
+    """Dispatch a command and yield results as strings.
+
+    Parameters
+    ----------
+    command:
+        Name of the API function to invoke.
+    params:
+        Optional dictionary of keyword arguments for the command.
+    user, session, think, config:
+        Context passed to API functions when required.
+    chat:
+        Active :class:`TeamChatSession` for ``team_chat`` commands. May be
+        ``None`` for other calls.
+    """
+
+    params = params or {}
+
+    if command in {"team_chat", "chat"}:
+        prompt = str(params.get("prompt", ""))
+        if chat is not None:
+            async for part in _yield_stream(chat.chat_stream(prompt)):
+                yield part
+        else:
+            async for part in _yield_stream(
+                team_chat(
+                    prompt,
+                    user=user,
+                    session=session,
+                    think=think,
+                    config=config,
+                )
+            ):
+                yield part
+        return
+
+    if command == "solo_chat":
+        prompt = str(params.get("prompt", ""))
+        async for part in _yield_stream(
+            solo_chat(
+                prompt,
+                user=user,
+                session=session,
+                think=think,
+                config=config,
+            )
+        ):
+            yield part
+        return
+
+    if command == "upload_document":
+        file_path = str(params["file_path"])
+        result = await upload_document(
+            file_path,
+            user=user,
+            session=session,
+            config=config,
+        )
+        yield json.dumps({"result": result})
+        return
+
+    if command == "list_dir":
+        path = str(params["path"])
+        listing = await list_dir(path, user=user)
+        yield json.dumps({"result": list(listing)})
+        return
+
+    if command == "read_file":
+        path = str(params["path"])
+        content = await read_file(path, user=user)
+        yield json.dumps({"result": content})
+        return
+
+    if command == "write_file":
+        path = str(params["path"])
+        content = str(params.get("content", ""))
+        result = await write_file(path, content, user=user)
+        yield json.dumps({"result": result})
+        return
+
+    if command == "delete_path":
+        path = str(params["path"])
+        result = await delete_path(path, user=user)
+        yield json.dumps({"result": result})
+        return
+
+    if command == "vm_execute":
+        cmd = str(params["command"])
+        timeout = params.get("timeout")
+        if timeout is not None:
+            timeout = int(timeout)
+        result = await vm_execute(cmd, user=user, timeout=timeout)
+        yield json.dumps({"result": result})
+        return
+
+    if command == "send_notification":
+        message = str(params["message"])
+        send_notification(message, user=user)
+        yield json.dumps({"result": "ok"})
+        return
+
+    raise ValueError(f"Unknown command: {command}")
+
+
+__all__ = ["dispatch_command"]

--- a/run_ws.py
+++ b/run_ws.py
@@ -1,18 +1,17 @@
 from __future__ import annotations
 
-"""Interactive WebSocket client for streaming chat messages.
+"""Command line WebSocket client for :mod:`agent.server` endpoints.
 
-This script connects to an :class:`~agent.server.AgentWebSocketServer` instance
-and keeps the WebSocket connection open indefinitely. User prompts are sent as
-soon as they are entered while LLM responses and VM notifications are streamed
-back immediately. The connection remains open so that notifications can be
-delivered even when the user is idle.
+The script exposes convenience subcommands matching the available WebSocket
+API. It supports interactive team chat as well as file and VM operations. The
+``solo_chat`` endpoint is intentionally omitted.
 """
 
 import argparse
 import asyncio
 from contextlib import suppress
 
+import json
 import websockets
 
 from agent.utils.logging import get_logger
@@ -21,7 +20,7 @@ _LOG = get_logger(__name__)
 
 
 async def _receiver(ws: websockets.WebSocketClientProtocol) -> None:
-    """Print all messages received from the server."""
+    """Print all messages received from ``ws``."""
 
     try:
         async for msg in ws:
@@ -31,19 +30,19 @@ async def _receiver(ws: websockets.WebSocketClientProtocol) -> None:
 
 
 async def chat(uri: str, message: str) -> None:
-    """Connect to ``uri`` and interactively exchange chat messages."""
+    """Interactively exchange team chat messages on ``uri``."""
 
     async with websockets.connect(uri) as ws:
         _LOG.info("Connected to %s", uri)
         if message:
-            await ws.send(message)
+            await ws.send(json.dumps({"command": "team_chat", "args": {"prompt": message}}))
 
         recv_task = asyncio.create_task(_receiver(ws))
         try:
             loop = asyncio.get_running_loop()
             while True:
                 prompt = await loop.run_in_executor(None, input, "> ")
-                await ws.send(prompt)
+                await ws.send(json.dumps({"command": "team_chat", "args": {"prompt": prompt}}))
         except KeyboardInterrupt:
             pass
         finally:
@@ -57,35 +56,97 @@ def _build_uri(host: str, port: int, user: str, session: str, think: bool) -> st
     return f"ws://{host}:{port}/?user={user}&session={session}&think={think_val}"
 
 
+async def request(uri: str, command: str, **params: object) -> None:
+    """Send a single command and print the server response."""
+
+    async with websockets.connect(uri) as ws:
+        await ws.send(json.dumps({"command": command, "args": params}))
+        try:
+            while True:
+                message = await ws.recv()
+                print(message, end="", flush=True)
+                break
+        except websockets.ConnectionClosed:
+            _LOG.info("Connection closed by server")
+
+
+async def _main(args: argparse.Namespace) -> None:
+    uri = _build_uri(args.host, args.port, args.user, args.session, args.think)
+    cmd = args.command
+
+    if cmd == "chat":
+        await chat(uri, args.message)
+        return
+
+    if cmd == "upload":
+        await request(uri, "upload_document", file_path=args.path)
+        return
+
+    if cmd == "list":
+        await request(uri, "list_dir", path=args.path)
+        return
+
+    if cmd == "read":
+        await request(uri, "read_file", path=args.path)
+        return
+
+    if cmd == "write":
+        await request(uri, "write_file", path=args.path, content=args.content)
+        return
+
+    if cmd == "delete":
+        await request(uri, "delete_path", path=args.path)
+        return
+
+    if cmd == "exec":
+        await request(uri, "vm_execute", command=args.command_str, timeout=args.timeout)
+        return
+
+    if cmd == "notify":
+        await request(uri, "send_notification", message=args.message)
+
+
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Interactive WebSocket client")
+    parser = argparse.ArgumentParser(description="WebSocket API client")
     parser.add_argument("--host", default="localhost", help="Server host")
     parser.add_argument("--port", type=int, default=8765, help="Server port")
     parser.add_argument("--user", default="demo", help="Username")
     parser.add_argument("--session", default="ws", help="Session identifier")
     think_group = parser.add_mutually_exclusive_group()
-    think_group.add_argument(
-        "--think",
-        dest="think",
-        action="store_true",
-        help="Enable model thinking (default)",
-    )
-    think_group.add_argument(
-        "--no-think",
-        dest="think",
-        action="store_false",
-        help="Disable model thinking",
-    )
+    think_group.add_argument("--think", dest="think", action="store_true", help="Enable model thinking (default)")
+    think_group.add_argument("--no-think", dest="think", action="store_false", help="Disable model thinking")
     parser.set_defaults(think=True)
-    parser.add_argument(
-        "--message",
-        default="Hello from the client!",
-        help="Optional message to send on connect",
-    )
-    args = parser.parse_args()
 
-    uri = _build_uri(args.host, args.port, args.user, args.session, args.think)
-    asyncio.run(chat(uri, args.message))
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    chat_p = sub.add_parser("chat", help="Interactive team chat")
+    chat_p.add_argument("--message", default="", help="Initial prompt")
+
+    up_p = sub.add_parser("upload", help="Upload document")
+    up_p.add_argument("path", help="Path to local file")
+
+    list_p = sub.add_parser("list", help="List directory")
+    list_p.add_argument("path", help="Path in VM")
+
+    read_p = sub.add_parser("read", help="Read file")
+    read_p.add_argument("path", help="Path in VM")
+
+    write_p = sub.add_parser("write", help="Write file")
+    write_p.add_argument("path", help="Path in VM")
+    write_p.add_argument("content", help="Content to write")
+
+    del_p = sub.add_parser("delete", help="Delete path")
+    del_p.add_argument("path", help="Path in VM")
+
+    exec_p = sub.add_parser("exec", help="Execute command in VM")
+    exec_p.add_argument("command_str", help="Command to run")
+    exec_p.add_argument("--timeout", type=int, default=None, help="Execution timeout")
+
+    notify_p = sub.add_parser("notify", help="Send notification")
+    notify_p.add_argument("message", help="Notification message")
+
+    args = parser.parse_args()
+    asyncio.run(_main(args))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add dispatch module for websocket commands
- expose API functions over websocket using new `dispatch_command` helper
- document JSON WebSocket requests
- extend sample client `run_ws.py` with CLI for all endpoints except solo chat

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68545ba1f7bc83219f02796cd3a9b025