### PR TITLE
Fix circular import when running python -m agent

### DIFF
--- a/agent/simple.py
+++ b/agent/simple.py
@@ -8,7 +8,6 @@ import shlex
 
 import shutil
 
-from .sessions.team import TeamChatSession
 from .config import Config, DEFAULT_CONFIG
 from .vm import VMRegistry
 from .db import add_document
@@ -65,6 +64,8 @@ async def team_chat(
     config: Config | None = None,
     extra: dict[str, str] | None = None,
 ) -> AsyncIterator[str]:
+    from .sessions.team import TeamChatSession
+
     async with TeamChatSession(
         user=user,
         session=session,


### PR DESCRIPTION
## Summary
- avoid importing `TeamChatSession` at module import time
- import it lazily in `team_chat`

## Testing
- `python -m agent` *(fails: ModuleNotFoundError: No module named 'whisper')*

------
https://chatgpt.com/codex/tasks/task_e_6856dc1ba9c88321a4c54194de9e0fe0