### PR TITLE
Add Dockerfile for WebSocket server

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+# Exclude Git history and development files
+.git
+__pycache__/
+*.py[cod]
+*.log
+uploads/
+vm_state/
+returns/
+.env
+*.db

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+# syntax=docker/dockerfile:1
+
+FROM python:3.11-slim AS runtime
+
+# Install OS-level dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    ffmpeg \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Copy dependency descriptors
+COPY requirements.txt ./
+
+# Install Python dependencies
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy application code
+COPY . .
+
+EXPOSE 8765
+
+CMD ["python", "-m", "agent"]


### PR DESCRIPTION
## Summary
- create Dockerfile that installs dependencies and launches the WS API
- include .dockerignore to trim build context

## Testing
- `python -m py_compile agent/__main__.py agent/server/__main__.py agent/server/websocket.py`
- `pip install -r requirements.txt` *(fails: Building wheel for peewee finished with status 'canceled')*

------
https://chatgpt.com/codex/tasks/task_e_6857fd990f7c8321adb9a4f7399245a7