### PR TITLE
Fix file upload handling

### DIFF
--- a/agent/api.py
+++ b/agent/api.py
@@ -120,7 +120,7 @@ async def upload_document(
 
 
 async def upload_data(
-    data: bytes,
+    data: bytes | str,
     filename: str,
     *,
     user: str = "default",
@@ -134,6 +134,8 @@ async def upload_data(
     dest = Path(cfg.upload_dir) / user
     dest.mkdir(parents=True, exist_ok=True)
     target = dest / safe_name
+    if isinstance(data, str):
+        data = data.encode()
     target.write_bytes(data)
 
     vm = VMRegistry.acquire(user, session, config=cfg)

--- a/agent/chat/session.py
+++ b/agent/chat/session.py
@@ -194,13 +194,15 @@ class ChatSession:
         add_document(self._user.username, str(target), src.name)
         return f"/data/{src.name}"
 
-    def upload_data(self, data: bytes, filename: str) -> str:
+    def upload_data(self, data: bytes | str, filename: str) -> str:
         """Save ``data`` as ``filename`` for access inside the VM."""
 
         dest = Path(self._config.upload_dir) / self._user.username
         dest.mkdir(parents=True, exist_ok=True)
         safe_name = sanitize_filename(filename)
         target = dest / safe_name
+        if isinstance(data, str):
+            data = data.encode()
         target.write_bytes(data)
 
         if self._vm is not None:

--- a/frontend/lib/useAgentChat.ts
+++ b/frontend/lib/useAgentChat.ts
@@ -64,7 +64,10 @@ export function useAgentChat(options: UseAgentChatOptions = {}) {
       setMessages((prev) => {
         const last = prev[prev.length - 1];
         if (last && last.role === "assistant" && !last.file) {
-          const updated = { ...last, content: last.content + part };
+          const updated = {
+            ...last,
+            content: last.content + (last.content ? "\n\n" : "") + part,
+          };
           return [...prev.slice(0, -1), updated];
         }
         return [


### PR DESCRIPTION
## Summary
- handle string input in `upload_data` helpers
- prepend newlines between streamed chunks on the frontend

## Testing
- `python -m py_compile agent/api.py agent/chat/session.py`
- `npx tsc -p frontend/tsconfig.json` *(fails: Cannot find module 'next' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_685acabd2e44832192c64860d6d7906e