### PR TITLE
Enable binary file uploads via websocket

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,11 @@ Arguments:
 Upload a file for the VM. Provide either:
 - `file_path` – path on the server host, or
 - `file_data` and `file_name` – base64 encoded bytes and filename
+  
+Binary uploads are also supported by sending a WebSocket binary frame.
+Prefix the frame with a 4‑byte big‑endian header length followed by a
+JSON header (containing the command and `file_name`) and the raw file
+bytes. The frontend uses this format when uploading files.
 
 Returns: `{ "result": "/data/<name>" }`.
 


### PR DESCRIPTION
## Summary
- support binary WebSocket messages in the server
- send file uploads as binary frames from the frontend
- document the binary upload format in the README

## Testing
- `npm install`
- `npm run build` *(fails: useSearchParams should be wrapped in a suspense boundary)*

------
https://chatgpt.com/codex/tasks/task_e_685ad3a3e2608321a6f67ea755ea5752