### PR TITLE
Fix Docker build by pulling model at runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 # Install Ollama
 RUN curl -fsSL https://ollama.com/install.sh | sh
-RUN ollama pull ${OLLAMA_MODEL}
+
+# The Ollama model is pulled at runtime by the entrypoint script. Pulling during
+# build requires a running `ollama` server which isn't available in the build
+# environment, leading to failures. Let the entrypoint handle the pull instead.
+
 
 WORKDIR /app
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,9 @@ docker build -t os-agent .
 docker run -p 8765:8765 -p 11434:11434 os-agent
 ```
 
+The Ollama model specified by `OLLAMA_MODEL` is downloaded when the container
+starts. Building the image does not require the model to be present.
+
 Environment variables allow customising the defaults:
 
 | Variable | Description | Default |


### PR DESCRIPTION
## Summary
- avoid running `ollama pull` during the Docker build
- document runtime model download in README

## Testing
- `python -m pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_685d77f7b3bc8321b5654148fcbc0b47