### PR TITLE
Fix dynamic websocket connection URL

### DIFF
--- a/frontend/lib/useAgentChat.ts
+++ b/frontend/lib/useAgentChat.ts
@@ -1,10 +1,11 @@
 import { useEffect, useRef, useState, useCallback } from "react";
 import { Base64 } from "js-base64";
 
-const DEFAULT_WS_URL = process.env.NEXT_PUBLIC_AGENT_WS_URL || "ws://localhost:8765";
-
 function buildWSUrl(user: string, session: string, think: boolean): string {
-  const url = new URL(DEFAULT_WS_URL);
+  const base =
+    process.env.NEXT_PUBLIC_AGENT_WS_URL ||
+    `ws://${typeof window !== "undefined" ? window.location.hostname : "localhost"}:8765`;
+  const url = new URL(base);
   url.searchParams.set("user", user);
   url.searchParams.set("session", session);
   url.searchParams.set("think", think ? "true" : "false");


### PR DESCRIPTION
## Summary
- compute websocket URL at runtime when no NEXT_PUBLIC_AGENT_WS_URL is set

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6860451b199c83219821ff78ea4a8c53